### PR TITLE
Mpi io species

### DIFF
--- a/para/parameters_iotest
+++ b/para/parameters_iotest
@@ -8,5 +8,11 @@
 	  x1min=0d0 x2min=0 x3min=0d0
 	  fmr_max=0 /
 
+! eostype : 0='ideal gas', 1='ideal gas + radiation pressure'
+! compswitch:0=uniform,1=spherical,2=advection(3=reaction?)
+! muconst : mean molecular weight (if compswitch=0 or background)
+! spn : number of species (>=3)
+&eos_con eostype = 1 eoserr=1d-15 compswitch=2 muconst=0.62d0 spn=8 /
+
 ! gravswitch:0=off,1=point source,2=MICCG,3=Hyperbolic
 &gravcon gravswitch=0 /

--- a/src/io.F90
+++ b/src/io.F90
@@ -182,7 +182,7 @@ subroutine read_array_1d_char(fh, arr, istart, iend)
 end subroutine read_array_1d_char
 
 subroutine read_array_3d_real8(fh, arr, istart, iend, jstart, jend, kstart, kend)
-  use mpi_utils, only: type_mpi_array
+  use mpi_utils, only: mpitype_array3d_real8
   integer, intent(in) :: fh
   real(8), allocatable, intent(inout) :: arr(:,:,:) ! use allocatable attribute to preserve lower and upper bound indices
   integer, intent(in) :: istart, iend, jstart, jend, kstart, kend
@@ -190,9 +190,9 @@ subroutine read_array_3d_real8(fh, arr, istart, iend, jstart, jend, kstart, kend
   integer :: nbuff
   nbuff = (iend-istart+1)*(jend-jstart+1)*(kend-kstart+1)
 
-  call mpi_file_set_view(fh, offset, MPI_DOUBLE_PRECISION, type_mpi_array, 'native', MPI_INFO_NULL, ierr)
+  call mpi_file_set_view(fh, offset, MPI_DOUBLE_PRECISION, mpitype_array3d_real8, 'native', MPI_INFO_NULL, ierr)
   call mpi_file_read_all(fh, arr(istart:iend,jstart:jend,kstart:kend), nbuff, MPI_DOUBLE_PRECISION, MPI_STATUS_IGNORE, ierr)
-  call update_offset(fh, type_mpi_array)
+  call update_offset(fh, mpitype_array3d_real8)
 #else
   read(fh) arr(istart:iend,jstart:jend,kstart:kend)
 #endif
@@ -284,7 +284,7 @@ subroutine write_real8(fh, var)
 end subroutine write_real8
 
 subroutine write_array_3d_real8(fh, arr, istart, iend, jstart, jend, kstart, kend)
-  use mpi_utils, only: type_mpi_array
+  use mpi_utils, only: mpitype_array3d_real8
   integer, intent(in) :: fh
   real(8), intent(in), allocatable :: arr(:,:,:) ! use allocatable attribute to preserve lower and upper bound indices
   integer, intent(in) :: istart, iend, jstart, jend, kstart, kend
@@ -295,7 +295,7 @@ subroutine write_array_3d_real8(fh, arr, istart, iend, jstart, jend, kstart, ken
   nbuff = (iend-istart+1)*(jend-jstart+1)*(kend-kstart+1)
 
   call get_file_end(fh, end_bytes)
-  call mpi_file_set_view(fh, end_bytes, MPI_REAL8, type_mpi_array, 'native', MPI_INFO_NULL, ierr)
+  call mpi_file_set_view(fh, end_bytes, MPI_REAL8, mpitype_array3d_real8, 'native', MPI_INFO_NULL, ierr)
   call mpi_file_write_all(fh, arr(istart:iend,jstart:jend,kstart:kend), nbuff, MPI_REAL8, MPI_STATUS_IGNORE, ierr)
 #else
   write(fh) arr(istart:iend,jstart:jend,kstart:kend)

--- a/src/iotest.f90
+++ b/src/iotest.f90
@@ -48,7 +48,7 @@ module iotest_mod
       do i = is, ie
         do j = js, je
           do k = ks, ke
-            spc(a,i,j,k) = 8.d0 + 1.d-2*i + 1.d-4*j + 1.d-6*k
+            spc(a,i,j,k) = 8.d0 + 1.d0*a + 1.d-2*i + 1.d-4*j + 1.d-6*k
           end do
         end do
       end do
@@ -101,7 +101,7 @@ module iotest_mod
         do j = js, je
           do k = ks, ke
             err = 0.d0
-            err = err + abs(spc(a,i,j,k) - (8.d0 + 1.d-2*i + 1.d-4*j + 1.d-6*k))
+            err = err + abs(spc(a,i,j,k) - (8.d0 + 1.d0*a + 1.d-2*i + 1.d-4*j + 1.d-6*k))
             if (err > 0.d0) then
               print*, 'Error in spc values at a=',a,'i=',i,'j=',j,'k=',k,'err=',err
               numerr = numerr + 1

--- a/src/mpi_domain.F90
+++ b/src/mpi_domain.F90
@@ -257,18 +257,30 @@ module mpi_domain
    subroutine setup_mpi_io
 #ifdef MPI
       use mpi
-      use mpi_utils, only: mpitype_array3d_real8
+      use mpi_utils, only: mpitype_array3d_real8, mpitype_array4d_real8
       use grid
-      integer, dimension(3) :: dims, sizes, subsizes, starts
+      use settings, only: spn, compswitch
+      integer, dimension(3) :: sizes3, subsizes3, starts3
+      integer, dimension(4) :: sizes4, subsizes4, starts4
       integer :: ierr
 
       ! Set up the subarray which selects only the real cells for I/O
-      sizes = [ie_global-is_global+1,je_global-js_global+1,ke_global-ks_global+1]
-      subsizes = [ie-is+1,je-js+1,ke-ks+1]
-      starts = [is-1,js-1,ks-1]
+      sizes3 = [ie_global-is_global+1,je_global-js_global+1,ke_global-ks_global+1]
+      subsizes3 = [ie-is+1,je-js+1,ke-ks+1]
+      starts3 = [is-1,js-1,ks-1]
 
-      call mpi_type_create_subarray(3, sizes, subsizes, starts, MPI_ORDER_FORTRAN, MPI_DOUBLE_PRECISION, mpitype_array3d_real8, ierr)
+      call mpi_type_create_subarray(3, sizes3, subsizes3, starts3, MPI_ORDER_FORTRAN, MPI_DOUBLE_PRECISION, mpitype_array3d_real8, ierr)
       call mpi_type_commit(mpitype_array3d_real8, ierr)
+
+      if (compswitch>=2) then
+         ! Set up the subarray for spc
+         sizes4 = [spn,ie_global-is_global+1,je_global-js_global+1,ke_global-ks_global+1]
+         subsizes4 = [spn,ie-is+1,je-js+1,ke-ks+1]
+         starts4 = [0,is-1,js-1,ks-1]
+
+         call mpi_type_create_subarray(4, sizes4, subsizes4, starts4, MPI_ORDER_FORTRAN, MPI_DOUBLE_PRECISION, mpitype_array4d_real8, ierr)
+         call mpi_type_commit(mpitype_array4d_real8, ierr)
+      endif
 #endif
    end subroutine setup_mpi_io
 

--- a/src/mpi_domain.F90
+++ b/src/mpi_domain.F90
@@ -257,7 +257,7 @@ module mpi_domain
    subroutine setup_mpi_io
 #ifdef MPI
       use mpi
-      use mpi_utils, only: type_mpi_array
+      use mpi_utils, only: mpitype_array3d_real8
       use grid
       integer, dimension(3) :: dims, sizes, subsizes, starts
       integer :: ierr
@@ -267,8 +267,8 @@ module mpi_domain
       subsizes = [ie-is+1,je-js+1,ke-ks+1]
       starts = [is-1,js-1,ks-1]
 
-      call mpi_type_create_subarray(3, sizes, subsizes, starts, MPI_ORDER_FORTRAN, MPI_DOUBLE_PRECISION, type_mpi_array, ierr)
-      call mpi_type_commit(type_mpi_array, ierr)
+      call mpi_type_create_subarray(3, sizes, subsizes, starts, MPI_ORDER_FORTRAN, MPI_DOUBLE_PRECISION, mpitype_array3d_real8, ierr)
+      call mpi_type_commit(mpitype_array3d_real8, ierr)
 #endif
    end subroutine setup_mpi_io
 

--- a/src/mpi_utils.F90
+++ b/src/mpi_utils.F90
@@ -11,7 +11,7 @@ module mpi_utils
 
   public :: allreduce_mpi
 
-  integer :: myrank, nprocs, mpitype_array3d_real8
+  integer :: myrank, nprocs, mpitype_array3d_real8, mpitype_array4d_real8
 
   contains
 

--- a/src/mpi_utils.F90
+++ b/src/mpi_utils.F90
@@ -11,7 +11,7 @@ module mpi_utils
 
   public :: allreduce_mpi
 
-  integer :: myrank, nprocs, type_mpi_array
+  integer :: myrank, nprocs, mpitype_array3d_real8
 
   contains
 


### PR DESCRIPTION
Add functionality for writing `spc` and `species` arrays with/without MPI

These arrays are now also part of `iotest`