### PR TITLE
Implement MPI IO for sinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.o
 *.mod
 hormone
+*.bin
+*.dat

--- a/para/parameters_iotest
+++ b/para/parameters_iotest
@@ -18,3 +18,8 @@
 
 ! gravswitch:0=off,1=point source,2=MICCG,3=Hyperbolic
 &gravcon gravswitch=0 /
+
+! include_sinks: switch for sink particles
+! nsink: number of sink particles
+!!! other quantities should be given in initial condition file
+&sinkcon include_sinks=.true. nsink=2 /

--- a/src/iotest.f90
+++ b/src/iotest.f90
@@ -18,6 +18,7 @@ module iotest_mod
     use profiler_mod
     use readbin_mod
     use settings, only: spn
+    use sink_mod, only: sink, nsink, sink_prop
 
     integer:: a,i,j,k,numerr
     real(8):: err
@@ -54,10 +55,23 @@ module iotest_mod
       species(a) = 'spc'//trim(speci)
     end do
 
+    do i=1,nsink
+      sink(i)%i = 1*i
+      sink(i)%j = 10*i
+      sink(i)%k = 100*i
+      sink(i)%mass = 1.d0*i
+      sink(i)%softfac = 10.d0*i
+      sink(i)%lsoft = 100.d0*i
+      sink(i)%locres = 1000.d0*i
+      sink(i)%dt = 10000.d0*i
+      sink(i)%x = (/1.d0*i,10.d0*i,100.d0*i/)
+      sink(i)%v = (/2.d0*i,20.d0*i,200.d0*i/)
+      sink(i)%a = (/3.d0*i,30.d0*i,300.d0*i/)
+      sink(i)%xpol = (/4.d0*i,40.d0*i,400.d0*i/)
+    end do
 
     ! Override the profiler time to prevent a divide by zero error during output
     wtime(wtlop) = 1.d0
-
 
     ! Write the arrays to file
     call output
@@ -75,6 +89,21 @@ module iotest_mod
 
     spc = 0.d0
     species = ''
+
+    do i = 1, size(sink)
+      sink(i)%i = 0
+      sink(i)%j = 0
+      sink(i)%k = 0
+      sink(i)%mass = 0.d0
+      sink(i)%softfac = 0.d0
+      sink(i)%lsoft = 0.d0
+      sink(i)%locres = 0.d0
+      sink(i)%dt = 0.d0
+      sink(i)%x = 0.d0
+      sink(i)%v = 0.d0
+      sink(i)%a = 0.d0
+      sink(i)%xpol = 0.d0
+    end do
 
     ! Read the arrays from file
     call readbin('data/bin00000000000s.dat')
@@ -118,6 +147,26 @@ module iotest_mod
       write(speci, '(I0)') a
       if (trim(species(a)) /= 'spc'//trim(speci)) then
         print*, 'Error in species names at a=',a,'species(a)=',trim(species(a))
+        numerr = numerr + 1
+      end if
+    end do
+
+    do i = 1, nsink
+      err = 0.d0
+      err = err + abs(sink(i)%i - 1*i)
+      err = err + abs(sink(i)%j - 10*i)
+      err = err + abs(sink(i)%k - 100*i)
+      err = err + abs(sink(i)%mass - 1.d0*i)
+      err = err + abs(sink(i)%softfac - 10.d0*i)
+      err = err + abs(sink(i)%lsoft - 100.d0*i)
+      err = err + abs(sink(i)%locres - 1000.d0*i)
+      err = err + abs(sink(i)%dt - 10000.d0*i)
+      err = err + sum(abs(sink(i)%x - (/1.d0*i, 10.d0*i, 100.d0*i/)))
+      err = err + sum(abs(sink(i)%v - (/2.d0*i, 20.d0*i, 200.d0*i/)))
+      err = err + sum(abs(sink(i)%a - (/3.d0*i, 30.d0*i, 300.d0*i/)))
+      err = err + sum(abs(sink(i)%xpol - (/4.d0*i, 40.d0*i, 400.d0*i/)))
+      if (err > 0.d0) then
+        print*, 'Error in sink array values at i=', i, 'err=', err
         numerr = numerr + 1
       end if
     end do

--- a/src/iotest.f90
+++ b/src/iotest.f90
@@ -69,6 +69,7 @@ module iotest_mod
       sink(i)%a = (/3.d0*i,30.d0*i,300.d0*i/)
       sink(i)%xpol = (/4.d0*i,40.d0*i,400.d0*i/)
     end do
+    call open_sinkfile
 
     ! Override the profiler time to prevent a divide by zero error during output
     wtime(wtlop) = 1.d0

--- a/src/mpi_domain.F90
+++ b/src/mpi_domain.F90
@@ -277,7 +277,7 @@ module mpi_domain
       use mpi
       use mpi_utils, only: mpitype_array3d_real8, mpitype_array4d_real8
       use grid
-      use settings, only: spn, compswitch
+      use settings, only: spn, compswitch, include_sinks
       integer, dimension(3) :: sizes3, subsizes3, starts3
       integer, dimension(4) :: sizes4, subsizes4, starts4
       integer :: ierr
@@ -299,8 +299,52 @@ module mpi_domain
          call mpi_type_create_subarray(4, sizes4, subsizes4, starts4, MPI_ORDER_FORTRAN, MPI_DOUBLE_PRECISION, mpitype_array4d_real8, ierr)
          call mpi_type_commit(mpitype_array4d_real8, ierr)
       endif
+
+      if (include_sinks) then
+         call create_sink_type_mpi
+      endif
 #endif
    end subroutine setup_mpi_io
+
+   subroutine create_sink_type_mpi
+      use mpi_utils, only: mpitype_sink_prop
+      use sink_mod, only: sink_prop
+      type(sink_prop) :: sink
+      integer, parameter :: nattr = 12
+      integer, dimension(nattr) :: types, blocklengths
+      integer(kind=MPI_ADDRESS_KIND), dimension(nattr) :: offsets
+      integer :: ierr
+
+      ! Get the addresses of each component of sink_prop
+      call MPI_Get_address(sink%i, offsets(1), ierr)
+      call MPI_Get_address(sink%j, offsets(2), ierr)
+      call MPI_Get_address(sink%k, offsets(3), ierr)
+      call MPI_Get_address(sink%mass, offsets(4), ierr)
+      call MPI_Get_address(sink%softfac, offsets(5), ierr)
+      call MPI_Get_address(sink%lsoft, offsets(6), ierr)
+      call MPI_Get_address(sink%locres, offsets(7), ierr)
+      call MPI_Get_address(sink%dt, offsets(8), ierr)
+      call MPI_Get_address(sink%x, offsets(9), ierr)
+      call MPI_Get_address(sink%v, offsets(10), ierr)
+      call MPI_Get_address(sink%a, offsets(11), ierr)
+      call MPI_Get_address(sink%xpol, offsets(12), ierr)
+
+      ! Compute offsets as relative to the start of sink
+      offsets = offsets - offsets(1)
+
+      ! Set the blocklengths (number of elements in each block)
+      blocklengths = (/1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 3/)
+
+      ! Set the types (type of each block)
+      types = (/MPI_INTEGER, MPI_INTEGER, MPI_INTEGER, \
+                MPI_DOUBLE_PRECISION, MPI_DOUBLE_PRECISION, MPI_DOUBLE_PRECISION, MPI_DOUBLE_PRECISION, MPI_DOUBLE_PRECISION, \
+                MPI_DOUBLE_PRECISION, MPI_DOUBLE_PRECISION, MPI_DOUBLE_PRECISION, MPI_DOUBLE_PRECISION/)
+
+      ! Create the custom datatype
+      call MPI_Type_create_struct(nattr, blocklengths, offsets, types, mpitype_sink_prop, ierr)
+      call MPI_Type_commit(mpitype_sink_prop, ierr)
+
+   end subroutine create_sink_type_mpi
 
    subroutine prime_factors(n, factors, num_factors)
       ! Compute the prime factors of a number

--- a/src/mpi_domain.F90
+++ b/src/mpi_domain.F90
@@ -307,6 +307,7 @@ module mpi_domain
    end subroutine setup_mpi_io
 
    subroutine create_sink_type_mpi
+#ifdef MPI
       use mpi_utils, only: mpitype_sink_prop
       use sink_mod, only: sink_prop
       type(sink_prop) :: sink
@@ -343,7 +344,7 @@ module mpi_domain
       ! Create the custom datatype
       call MPI_Type_create_struct(nattr, blocklengths, offsets, types, mpitype_sink_prop, ierr)
       call MPI_Type_commit(mpitype_sink_prop, ierr)
-
+#endif
    end subroutine create_sink_type_mpi
 
    subroutine prime_factors(n, factors, num_factors)

--- a/src/mpi_domain.F90
+++ b/src/mpi_domain.F90
@@ -31,7 +31,7 @@ module mpi_domain
       integer, allocatable :: factors(:)
       integer :: num_factors, axis
       real(8) :: n_tmp(3)
-      integer, dimension(3) :: dims, sizes, subsizes, starts
+      integer, dimension(3) :: dims
       real(8) :: eff
       logical :: periods(3)
       integer :: mycoords(3)

--- a/src/mpi_domain.F90
+++ b/src/mpi_domain.F90
@@ -112,7 +112,7 @@ module mpi_domain
 
       do i = 1, nprocs
          if (myrank == i-1) then
-            write(*,'(A,I0,A,I4,A,I4,A,I4,A,I4,A,I0,A,I0,A,F5.2,A)') '  Rank ', myrank, ' has domain (', is, ':', ie, ',', js, ':', je, ',', ks, ':', ke, '), volume efficiency=', eff*100.d0, '%'
+            write(*,'(A,I0,A,I4,A,I4,A,I4,A,I4,A,I0,A,I0,A,F6.2,A)') '  Rank ', myrank, ' has domain (', is, ':', ie, ',', js, ':', je, ',', ks, ':', ke, '), volume efficiency=', eff*100.d0, '%'
          endif
          call MPI_Barrier(cart_comm, ierr)
       enddo

--- a/src/mpi_utils.F90
+++ b/src/mpi_utils.F90
@@ -11,7 +11,7 @@ module mpi_utils
 
   public :: allreduce_mpi
 
-  integer :: myrank, nprocs, mpitype_array3d_real8, mpitype_array4d_real8
+  integer :: myrank, nprocs, mpitype_array3d_real8, mpitype_array4d_real8, mpitype_sink_prop
 
   contains
 

--- a/src/output.f90
+++ b/src/output.f90
@@ -307,12 +307,14 @@ subroutine open_sinkfile
  use settings,only:include_sinks,sigfig,start
  use constants,only:msun
  use sink_mod,only:nsink,sink
+ use mpi_utils, only:myrank
 
  integer:: ierr,n
  character(len=50):: forma, forme, header
 
 !-----------------------------------------------------------------------------
 
+ if (myrank/=0) return
  if(.not.include_sinks)return
 
  write(forma,'("(a",i2,")")')sigfig+8 ! for strings
@@ -358,15 +360,17 @@ end subroutine open_sinkfile
 
 subroutine sink_output
 
- use settings,only:sigfig,include_sinks
- use grid,only:tn,time
- use sink_mod,only:nsink,sink
+ use settings,  only: sigfig,include_sinks
+ use grid,      only: tn,time
+ use sink_mod,  only: nsink,sink
+ use mpi_utils, only: myrank
 
  integer:: n
  character(len=50):: forme
 
 !-----------------------------------------------------------------------------
 
+ if (myrank/=0) return
  if(.not.include_sinks)return
 
  write(forme,'("(1x,1PE",i2,".",i2,"e2)")')sigfig+7,sigfig-1 ! for real numbers

--- a/src/sinks.f90
+++ b/src/sinks.f90
@@ -2,6 +2,7 @@ module sink_mod
  implicit none
 
  type sink_prop
+  sequence
   integer:: i,j,k
   real(8):: mass, softfac, lsoft, locres, dt
   real(8),dimension(1:3):: x,v,a,xpol


### PR DESCRIPTION
This PR implements I/O with MPI for the sink array

- Created custom MPI type for sinks
- Each task stores a copy of all sinks
- Added to iotest
- Added the 'sequence' attribute to sink_prop type to ensure attributes always appear in the same order in memory. Note: this doesn't ensure it's contiguous in memory -- the custom MPI type handles any 'holes' the compiler might create
- Only write ascii sink output on master task. Note: not tested.
- Note: actual integration of sinks with MPI not implemented yet
