### PR TITLE
MPI-compatible profiling

### DIFF
--- a/src/mpi_domain.F90
+++ b/src/mpi_domain.F90
@@ -203,8 +203,14 @@ module mpi_domain
       use grid
       use physval
       use profiler_mod
+      use mpi_utils
       
-      integer :: i
+      integer :: i, ierr
+
+      ! Timing: measure the time spent waiting for other tasks to catch up
+      call start_clock(wtwai)
+      call barrier_mpi
+      call stop_clock(wtwai)
 
       call start_clock(wtmpi)
 

--- a/src/mpi_domain.F90
+++ b/src/mpi_domain.F90
@@ -202,7 +202,12 @@ module mpi_domain
       use settings
       use grid
       use physval
+      use profiler_mod
+      
       integer :: i
+
+      call start_clock(wtmpi)
+
       ! Exchange data between MPI domains
       ! Scalar quantities: d, p, phi, spc
       ! Vector quantities: v1, v2, v3, b1, b2, b3
@@ -225,6 +230,8 @@ module mpi_domain
 
       call exchange_scalar(e)
       call exchange_scalar(eint)
+
+      call stop_clock(wtmpi)
 
    end subroutine exchange_mpi
 

--- a/src/mpi_utils.F90
+++ b/src/mpi_utils.F90
@@ -84,4 +84,11 @@ module mpi_utils
 
   end subroutine allreduce_mpi_int4
 
+  subroutine barrier_mpi
+#ifdef MPI
+    integer :: ierr
+    call MPI_BARRIER(MPI_COMM_WORLD, ierr)
+#endif
+  end subroutine
+
 end module mpi_utils

--- a/src/output.f90
+++ b/src/output.f90
@@ -1094,17 +1094,20 @@ subroutine profiler_output
   if(clock_on(i))wtime(i) = wtime(i) + omp_get_wtime()
  end do
 
- write(form1,'("(",i2,"X,3a12)")')maxlbl+1
- write(forml,'("(",i2,"a)")')maxlbl+1 + 3*12
+! Reduce clocks across MPI tasks
+ call reduce_clocks_mpi
+
+ write(form1,'("(",i2,"X4a12)")')maxlbl+1
+ write(forml,'("(",i2,"a)")')maxlbl+1 + 4*12
 
  open(newunit=ui,file='walltime.dat',status='replace')
- write(ui,form1)'wall_time','frac_loop','frac_tot'
+ write(ui,form1)'wall_time','frac_loop','frac_tot','imbalance'
 
  do i = 1, n_wt
-  if(get_layer(i)==wttot)write(ui,forml)('-',j=1,maxlbl+1+3*12)
+  if(get_layer(i)==wttot)write(ui,forml)('-',j=1,maxlbl+1+4*12)
   call profiler_output1(ui,i)
  end do
- write(ui,forml)('-',j=1,maxlbl+1+3*12)
+ write(ui,forml)('-',j=1,maxlbl+1+4*12)
  call profiler_output1(ui,wttot)
 
  close(ui)

--- a/src/output.f90
+++ b/src/output.f90
@@ -1079,10 +1079,11 @@ end subroutine write_bpt
 ! PURPOSE: To output wall time for each subroutine
 
 subroutine profiler_output
-
+ 
  use settings
  use profiler_mod
  use omp_lib
+ use mpi_utils, only:myrank
 
  integer:: ui,i,j
  character(len=30)::form1,forml
@@ -1097,20 +1098,22 @@ subroutine profiler_output
 ! Reduce clocks across MPI tasks
  call reduce_clocks_mpi
 
- write(form1,'("(",i2,"X4a12)")')maxlbl+1
- write(forml,'("(",i2,"a)")')maxlbl+1 + 4*12
+ if (myrank==0) then
+  write(form1,'("(",i2,"X4a12)")')maxlbl+1
+  write(forml,'("(",i2,"a)")')maxlbl+1 + 4*12
 
- open(newunit=ui,file='walltime.dat',status='replace')
- write(ui,form1)'wall_time','frac_loop','frac_tot','imbalance'
+  open(newunit=ui,file='walltime.dat',status='replace')
+  write(ui,form1)'wall_time','frac_loop','frac_tot','imbalance'
 
- do i = 1, n_wt
-  if(get_layer(i)==wttot)write(ui,forml)('-',j=1,maxlbl+1+4*12)
-  call profiler_output1(ui,i)
- end do
- write(ui,forml)('-',j=1,maxlbl+1+4*12)
- call profiler_output1(ui,wttot)
+  do i = 1, n_wt
+    if(get_layer(i)==wttot)write(ui,forml)('-',j=1,maxlbl+1+4*12)
+    call profiler_output1(ui,i)
+  end do
+  write(ui,forml)('-',j=1,maxlbl+1+4*12)
+  call profiler_output1(ui,wttot)
 
- close(ui)
+  close(ui)
+ endif
 
 ! Reactivate clocks
  do i = 0, n_wt

--- a/src/profiler.f90
+++ b/src/profiler.f90
@@ -2,7 +2,7 @@ module profiler_mod
  implicit none
 
  public:: init_profiler,profiler_output1,start_clock,stop_clock,reset_clock
- integer,parameter:: n_wt=23 ! number of profiling categories
+ integer,parameter:: n_wt=24 ! number of profiling categories
  real(8):: wtime(0:n_wt),wtime_max(0:n_wt),wtime_min(0:n_wt),wtime_avg(0:n_wt),imbalance(0:n_wt)
  integer,parameter:: &
   wtini=1 ,& ! initial conditions
@@ -28,6 +28,7 @@ module profiler_mod
   wtsnk=21,& ! sink particles
   wtout=22,& ! output
   wtmpi=23,& ! mpi exchange
+  wtwai=24,& ! mpi wait
   wttot=0    ! total
  integer,public:: parent(0:n_wt),maxlbl
  character(len=30),public:: routine_name(0:n_wt)
@@ -74,6 +75,7 @@ subroutine init_profiler
  parent(wtrfl) = wtrad ! radiative flux
  parent(wtsnk) = wtlop ! sink particles
  parent(wtmpi) = wtlop ! mpi exchange
+ parent(wtwai) = wtlop ! mpi wait
  parent(wttot) =-1     ! Total
 
 ! Make sure to keep routine name short
@@ -99,7 +101,8 @@ subroutine init_profiler
  routine_name(wtopc) = 'Opacity'     ! opacity
  routine_name(wtrfl) = 'Rad_flux'    ! radiative flux
  routine_name(wtsnk) = 'Sinks'       ! sink particles
- routine_name(wtmpi) = 'MPI'         ! MPI exchange
+ routine_name(wtmpi) = 'MPI exchange'! MPI exchange
+ routine_name(wtwai) = 'MPI wait'    ! MPI wait
  routine_name(wttot) = 'Total'       ! total
 
  do i = 0, n_wt


### PR DESCRIPTION
Each MPI task keeps its own profiling clocks. Prior to output, they reduce their clocks, and the master task writes the ASCII output.

The average walltime for each category gives the most meaningful diagnostic, because it indicates where time is spent. Simply taking the max may not be useful, because a task that finishes a step quickly will record less time in that step, but more time in the subsequent step, meaning the times may add up to more than the total time.

An additional column `imbalance` is added, which measures the fraction `(max - min)/avg` of each clock. 0% indicates that every task recorded the same amount of time within that clock, and a non-zero value indicates load imbalance.

A clock `wtmpi` is added to time the MPI neighbour exchange subroutine.

This is an example output:
```
                    wall_time   frac_loop    frac_tot   imbalance
-----------------------------------------------------------------
Setup           :      0.007s      0.772%      0.767%      0.866%
└─1st_Output    :      0.003s      0.294%      0.291%      2.975%
-----------------------------------------------------------------
Main_loop       :      0.882s    100.000%     99.233%      0.026%
├─Hydro         :      0.836s     94.841%     94.114%      7.413%
│ ├─Numflux     :      0.136s     15.440%     15.321%     26.138%
│ ├─RungeKutta  :      0.142s     16.061%     15.937%      8.005%
│ ├─Boundary    :      0.193s     21.868%     21.701%     92.815%
│ ├─Source      :      0.066s      7.513%      7.455%      2.938%
│ ├─Interpolate :      0.075s      8.499%      8.434%     13.761%
│ └─EoS         :      0.175s     19.887%     19.734%     23.404%
├─Timestep      :      0.042s      4.723%      4.687%    148.634%
├─Output        :      0.003s      0.357%      0.354%      7.659%
└─MPI           :      0.048s      5.465%      5.423%    237.173%
-----------------------------------------------------------------
Total           :      0.889s    100.773%    100.000%      0.020%
```
