### PR TITLE
Fix L2 norm, enable star_sph test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,7 @@ jobs:
           - orszagtang_xz
           - sedov_default
           - KHinstability
+          - star_sph
           - iotest
         flat:
           - no

--- a/para/parameters_orszagtang_xy
+++ b/para/parameters_orszagtang_xy
@@ -40,4 +40,4 @@
 	  bc1iv=0 bc1ov=0 bc2iv=0 bc2ov=0 bc3iv=0 bc3ov=0 eq_sym=.false. /
 
 ! test tolerance
-&testcon  test_tol=1d-15 /
+&testcon  test_tol=4d-15 /

--- a/para/parameters_orszagtang_xz
+++ b/para/parameters_orszagtang_xz
@@ -40,4 +40,4 @@
 	  bc1iv=0 bc1ov=0 bc2iv=0 bc2ov=0 bc3iv=0 bc3ov=0 eq_sym=.false. /
 
 ! test tolerance
-&testcon  test_tol=1d-15 /
+&testcon  test_tol=4d-15 /

--- a/para/parameters_orszagtang_yz
+++ b/para/parameters_orszagtang_yz
@@ -40,4 +40,4 @@
 	  bc1iv=0 bc1ov=0 bc2iv=0 bc2ov=0 bc3iv=0 bc3ov=0 eq_sym=.false. /
 
 ! test tolerance
-&testcon  test_tol=1d-15 /
+&testcon  test_tol=4d-15 /

--- a/para/parameters_sedov_default
+++ b/para/parameters_sedov_default
@@ -41,4 +41,4 @@
 	  bc1iv=1 bc1ov=2 bc2iv=0 bc2ov=0 bc3iv=0 bc3ov=0 eq_sym=.false. /
 
 ! test tolerance
-&testcon  test_tol=1d-14 /
+&testcon  test_tol=2d-14 /

--- a/para/parameters_star_sph
+++ b/para/parameters_star_sph
@@ -52,4 +52,4 @@
 	 gis=1 gie=1 gjs=1 gje=1 gks=1 gke=1 /
 
 ! test tolerance
-&testcon  test_tol=1d-15 /
+&testcon  test_tol=2d-5 /

--- a/src/tests.f90
+++ b/src/tests.f90
@@ -238,7 +238,7 @@ contains
      end if
      jump = maxval(ratio(var0(i-il:i+iu,j-jl:j+ju,k-kl:k+ku),base,floor))
 
-     relerr(i,j,k) = (var(i,j,k)-var0(i,j,k))!/denom*exp(1d0-jump)
+     relerr(i,j,k) = (var(i,j,k)-var0(i,j,k))/denom*exp(1d0-jump)
     end do
    end do
   end do


### PR DESCRIPTION
Fixes a bug caused by a debugging change being accidentally committed. This resulted in the L2 norm missing the denominator.

Enables the star_sph test with tolerance 2d-5.

Changes tolerance of other tests to account for denominator term:
- orszagtang: 4d-15
- sedov: 2d-14