### PR TITLE
Parallel IO for ascii output files

### DIFF
--- a/src/io.F90
+++ b/src/io.F90
@@ -73,6 +73,16 @@ subroutine open_file_write(filename, fh)
 #endif
 end subroutine open_file_write
 
+subroutine open_file_write_ascii(filename, fh)
+  character(len=*), intent(in) :: filename
+  integer, intent(out) :: fh
+#ifdef MPI
+  call mpi_file_open(MPI_COMM_WORLD, filename, MPI_MODE_CREATE + MPI_MODE_RDWR, MPI_INFO_NULL, fh, ierr)
+#else
+  open(newunit=fh, file=filename, status='replace', form='formatted', action='write')
+#endif
+end subroutine open_file_write_ascii
+
 subroutine open_file_read(filename, fh)
   character(len=*), intent(in) :: filename
   integer, intent(out) :: fh

--- a/src/io.F90
+++ b/src/io.F90
@@ -64,25 +64,13 @@ end subroutine get_file_end
 #endif
 
 subroutine open_file_write(filename, fh)
-  use mpi_utils, only: myrank
   character(len=*), intent(in) :: filename
   integer, intent(out) :: fh
-
-  if (myrank == 0) then
-    ! Create new file
-    open(newunit=fh, file=filename, status='replace', form='unformatted', action='write', access='stream')
 #ifdef MPI
-    ! Close the file so that other ranks can open it in MPI mode
-    close(fh)
+  call mpi_file_open(MPI_COMM_WORLD, filename, MPI_MODE_CREATE + MPI_MODE_RDWR, MPI_INFO_NULL, fh, ierr)
+#else
+  open(newunit=fh, file=filename, status='replace', form='unformatted', action='write', access='stream')
 #endif
-  end if
-
-#ifdef MPI
-  call mpi_barrier(MPI_COMM_WORLD, ierr)
-  call mpi_file_open(MPI_COMM_WORLD, filename, MPI_MODE_RDWR + MPI_MODE_APPEND, MPI_INFO_NULL, fh, ierr)
-  call mpi_barrier(MPI_COMM_WORLD, ierr)
-#endif
-
 end subroutine open_file_write
 
 subroutine open_file_read(filename, fh)

--- a/src/iotest.f90
+++ b/src/iotest.f90
@@ -295,6 +295,7 @@ module iotest_mod
         print*, 'Test failed'
         error stop 1
       else
+        call cleanup_files(tn=123, time=456.d0)
         print*, 'Test passed'
       endif
     endif
@@ -484,5 +485,42 @@ module iotest_mod
     end do
 
   end subroutine iotest_grid
+
+  subroutine cleanup_files(tn, time)
+    use output_mod, only: set_file_name
+    use mpi_utils, only: myrank
+    integer, intent(in) :: tn
+    real(8), intent(in) :: time
+    integer :: fh, stat
+    character(len=60) :: filename
+
+    if (myrank/=0) return
+
+    print*, 'Cleaning up files...'
+
+    open(newunit=fh, iostat=stat, file='data/extgrv.bin', status='old')
+    if (stat == 0) close(fh, status='delete')
+
+    open(newunit=fh, iostat=stat, file='data/gridfile.bin', status='old')
+    if (stat == 0) close(fh, status='delete')
+
+    open(newunit=fh, iostat=stat, file='data/gridfile.dat', status='old')
+    if (stat == 0) close(fh, status='delete')
+
+    open(newunit=fh, iostat=stat, file='data/sinks.dat', status='old')
+    if (stat == 0) close(fh, status='delete')
+
+    call set_file_name('bin', tn, time, filename)
+    open(newunit=fh, iostat=stat, file=trim(filename), status='old')
+    if (stat == 0) close(fh, status='delete')
+
+    call set_file_name('plt', tn, time, filename)
+    open(newunit=fh, iostat=stat, file=trim(filename), status='old')
+    if (stat == 0) close(fh, status='delete')
+
+    open(newunit=fh, iostat=stat, file='walltime.dat', status='old')
+    if (stat == 0) close(fh, status='delete')
+
+  end subroutine cleanup_files
 
 end module iotest_mod

--- a/src/mpi_domain.F90
+++ b/src/mpi_domain.F90
@@ -468,6 +468,7 @@ module mpi_domain
 
    logical function is_my_domain(i,j,k)
       use grid
+      use mpi_utils, only: barrier_mpi
       integer, intent(in) :: i, j, k
 
       if ( is<=i .and. i<=ie .and. js<=j .and. j<=je .and. ks<=k .and. k<=ke ) then
@@ -475,6 +476,8 @@ module mpi_domain
       else
          is_my_domain = .false.
       end if
+
+      call barrier_mpi
 
    end function
 

--- a/src/mpi_domain.F90
+++ b/src/mpi_domain.F90
@@ -470,8 +470,23 @@ module mpi_domain
       use grid
       use mpi_utils, only: barrier_mpi
       integer, intent(in) :: i, j, k
+      integer :: il, ir, jl, jr, kl, kr
 
-      if ( is<=i .and. i<=ie .and. js<=j .and. j<=je .and. ks<=k .and. k<=ke ) then
+      il = is
+      ir = ie
+      jl = js
+      jr = je
+      kl = ks
+      kr = ke
+
+      if (is==is_global) il = is_global - 2
+      if (ie==ie_global) ir = ie_global + 2
+      if (js==js_global) jl = js_global - 2
+      if (je==je_global) jr = je_global + 2
+      if (ks==ks_global) kl = ks_global - 2
+      if (ke==ke_global) kr = ke_global + 2
+
+      if ( il<=i .and. i<=ir .and. jl<=j .and. j<=jr .and. kl<=k .and. k<=kr ) then
          is_my_domain = .true.
       else
          is_my_domain = .false.

--- a/src/mpi_domain.F90
+++ b/src/mpi_domain.F90
@@ -466,4 +466,16 @@ module mpi_domain
 #endif
    end subroutine print_domain_decomposition
 
+   logical function is_my_domain(i,j,k)
+      use grid
+      integer, intent(in) :: i, j, k
+
+      if ( is<=i .and. i<=ie .and. js<=j .and. j<=je .and. ks<=k .and. k<=ke ) then
+         is_my_domain = .true.
+      else
+         is_my_domain = .false.
+      end if
+
+   end function
+
 end module mpi_domain

--- a/src/output.f90
+++ b/src/output.f90
@@ -22,6 +22,7 @@ subroutine output
  use settings,only:is_test
  use grid,only:tn
  use profiler_mod
+ use mpi_utils,only:barrier_mpi
 
  integer:: wtind
 
@@ -52,6 +53,8 @@ subroutine output
  call stop_clock(wtind)
 
  call profiler_output
+
+ call barrier_mpi
 
  return
 end subroutine output
@@ -1025,6 +1028,7 @@ subroutine write_ptc
  use physval,only:d,e
  use particle_mod
  use gravmod,only:grvphi
+ use mpi_utils,only:myrank
 
  character(len=50):: ptcfile
  integer::ui,i,j,k,n
@@ -1034,6 +1038,7 @@ subroutine write_ptc
 !-----------------------------------------------------------------------------
 
  if(.not.include_particles) return
+ if(myrank/=0) return
 
  call set_file_name('ptc',tn,time,ptcfile)
 
@@ -1108,6 +1113,7 @@ subroutine write_bpt
  use settings,only:include_particles
  use grid,only:tn,time
  use particle_mod
+ use mpi_utils,only:myrank
 
  character(len=50):: bptfile
  integer::ui
@@ -1115,6 +1121,7 @@ subroutine write_bpt
 !-----------------------------------------------------------------------------
 
  if(.not.include_particles) return
+ if(myrank/=0) return
 
  call set_file_name('bpt',tn,time,bptfile)
 

--- a/src/output.f90
+++ b/src/output.f90
@@ -744,33 +744,19 @@ end subroutine write_bin
 ! PURPOSE: To output ascii file for plotting
 
 subroutine write_plt
- ! TODO: MPI
-
  use settings
- use grid,only:is,ie,js,je,ks,ke,time,tn,dim
+ use grid
  use utils,only:gravpot1d
  use shockfind_mod,only:shockfind
- use mpi_utils, only:nprocs,myrank
-
- implicit none
-
+ use mpi_utils, only:myrank
+ use io, only:open_file_write_ascii, write_string, write_string_master, close_file
  character(len=50):: pltfile
  character(len=20):: header(50)='aaa',forma,forme,formi
+ character(len=200):: str
  integer:: i,j,k,n,ui,columns
 
- if (nprocs>1) then
-    if (myrank==0) then
-      write(*,'(60("*"))')
-      print*, 'WARNING: write_plt not implemented for nprocs>1'
-      write(*,'(60("*"))')
-    endif
-    return
- endif
-
-!-----------------------------------------------------------------------------
-
 ! Calculate gravitational potential here if spherical
- if(gravswitch==1) call gravpot1d
+ if(gravswitch==1) call gravpot1d    ! TODO: MPI
 ! Calculate shock position if required
  if(write_shock)call shockfind
 
@@ -781,41 +767,44 @@ subroutine write_plt
 
 ! Open file
  call set_file_name('plt',tn,time,pltfile)
- open(newunit=ui,file = pltfile, status='replace')
+ call open_file_write_ascii(pltfile,ui)
 
 ! Write time and time step
- write(ui,'(a,i7,a,1PE12.4e2,a)')&
+ write(str,'(a,i7,a,1PE12.4e2,a)')&
   '#tn =',tn,'  time= ',time/dt_unit_in_sec,dt_unit
+ call write_string_master(ui,str)
 
 ! Decide what quantities to write
  call get_header(header,columns)
  do n = 1, columns
-  write(ui,formi,advance='no') n+2*dim+1
+  write(str,formi) n+2*dim+1
+  call write_string_master(ui,str,advance=.false.)
  end do
- write(ui,'()')
+ call write_string_master(ui, '')
  do n = 1, columns
-  write(ui,forma,advance="no") trim(adjustl(header(n)))
+  write(str,forma) trim(adjustl(header(n)))
+  call write_string_master(ui,str,advance=.false.)
  end do
- write(ui,'()')
+ call write_string_master(ui, '')
 
 ! Write file
  select case (dim)
 ! 1D outputs
  case(1)
 
-  if(ie>is)then
-   j=js;k=ks
-   do i = is, ie
+  if(ie_global>is_global)then
+   j=js_global;k=ks_global
+   do i = is_global, ie_global
     call write_val(ui,i,j,k,forme,header)
    end do
-  elseif(je>js)then
-   i=is;k=ks
-   do j = js, je
+  elseif(je_global>js_global)then
+   i=is_global;k=ks_global
+   do j = js_global, je_global
     call write_val(ui,i,j,k,forme,header)
    end do
-  elseif(ke>ks)then
-   i=is;j=js
-   do k = ks, ke
+  elseif(ke_global>ks_global)then
+   i=is_global;j=js_global
+   do k = ks_global, ke_global
     call write_val(ui,i,j,k,forme,header)
    end do
   end if
@@ -823,81 +812,81 @@ subroutine write_plt
 ! 2D outputs
  case(2)
 
-  if(ke==ks)then! For 2D Cartesian, polar or axisymmetrical spherical
-   k=ks
+  if(ke_global==ks_global)then! For 2D Cartesian, polar or axisymmetrical spherical
+   k=ks_global
 ! output coordinate axis if cylindrical or spherical coordinates
    if(crdnt==1.or.crdnt==2)then
-    j=js
-    do i = is, ie
+    j=js_global
+    do i = is_global, ie_global
      call write_val(ui,i,j,k,forme,header)
     end do
-    write(ui,'()')
+    call write_string_master(ui, '')
    end if
 
-   do j = js, je
-    do i = is, ie
+   do j = js_global, je_global
+    do i = is_global, ie_global
      call write_val(ui,i,j,k,forme,header)
     end do
-    write(ui,'()')
+    call write_string_master(ui, '')
    end do
 
 ! output coordinate axis if cylindrical or spherical coordinates
    if(crdnt==1.or.crdnt==2)then
-    j=je
-    do i = is, ie
+    j=je_global
+    do i = is_global, ie_global
      call write_val(ui,i,j,k,forme,header)
     end do
-    write(ui,'()')
+    call write_string_master(ui, '')
    end if
 
-  elseif(je==js)then! mainly for 2D Cartesian or axisymmetrical cylindrical
-   j=js
-   do k = ks, ke, outres
+  elseif(je_global==js_global)then! mainly for 2D Cartesian or axisymmetrical cylindrical
+   j=js_global
+   do k = ks_global, ke_global, outres
 ! writing inner boundary for polar coordinates
-    if(crdnt==1.or.crdnt==2)call write_val(ui,is,j,k,forme,header)
-    do i = is, ie, outres
+    if(crdnt==1.or.crdnt==2)call write_val(ui,is_global,j,k,forme,header)
+    do i = is_global, ie_global, outres
      call write_val(ui,i,j,k,forme,header)
     end do
-    write(ui,'()')
+    call write_string_master(ui, '')
    end do
 
-  elseif(ie==is)then! For 2D Cartesian
+  elseif(ie_global==is_global)then! For 2D Cartesian
 !CAUTION: Not designed for cylindrical or spherical yet
-   i=is
-   do k = ks, ke
-    do j = js, je
+   i=is_global
+   do k = ks_global, ke_global
+    do j = js_global, je_global
      call write_val(ui,i,j,k,forme,header)
     end do
-    write(ui,'()')
+    call write_string_master(ui, '')
    end do
   end if
 
  case(3)
 
   if(crdnt==2)then
-   do j = je, je
-    do i = is, ie
-     call write_val(ui,i,j,ks,forme,header)
+   do j = je_global, je_global
+    do i = is_global, ie_global
+     call write_val(ui,i,j,ks_global,forme,header)
     end do
-    write(ui,'()')
+    call write_string_master(ui, '')
    end do
   end if
 
-  do k = ks, ke
-   do j = je, je
-    do i = is, ie
+  do k = ks_global, ke_global
+   do j = je_global, je_global
+    do i = is_global, ie_global
      call write_val(ui,i,j,k,forme,header)
     end do
-    write(ui,'()')
+    call write_string_master(ui, '')
    end do
   end do
 
   if(crdnt==2)then
-   do j = je, je
-    do i = is, ie
-     call write_val(ui,i,j,ke,forme,header)
+   do j = je_global, je_global
+    do i = is_global, ie_global
+     call write_val(ui,i,j,ke_global,forme,header)
     end do
-    write(ui,'()')
+    call write_string_master(ui, '')
    end do
   end if
 
@@ -905,9 +894,9 @@ subroutine write_plt
   stop 'Something wrong with dimension'
  end select
 
- close(ui)
+ call close_file(ui)
 
- print*,"Outputted: ",trim(pltfile)
+ if (myrank==0) print*,"Outputted: ",trim(pltfile)
 
 !othfile----------------------------------------------------------------------
 
@@ -915,60 +904,63 @@ subroutine write_plt
 
 ! Open file
   call set_file_name('oth',tn,time,pltfile)
-  open(newunit=ui,file = pltfile, status='replace')
+  call open_file_write_ascii(pltfile,ui)
 
 ! Write time and time step
-  write(ui,'(a,i7,a,1PE12.4e2,a)')&
+  write(str,'(a,i7,a,1PE12.4e2,a)')&
    '#tn =',tn,'  time= ',time/dt_unit_in_sec,dt_unit
+  call write_string_master(ui,str)
 ! Decide what quantities to write
   call get_header(header,columns)
   do n = 1, columns
-   write(ui,formi,advance='no') n+2*dim+1
+   write(str,formi) n+2*dim+1
+   call write_string_master(ui,str,advance=.false.)
   end do
-  write(ui,'()')
+  call write_string_master(ui, '')
   do n = 1, columns
-   write(ui,forma,advance="no") trim(adjustl(header(n)))
+   write(str,forma) trim(adjustl(header(n)))
+   call write_string_master(ui,str,advance=.false.)
   end do
-  write(ui,'()')
+  call write_string_master(ui, '')
 
   if(crdnt==2)then
 
-   k = ks
-   do i = is, ie
-    call write_val(ui,i,je,k,forme,header)
+   k = ks_global
+   do i = is_global, ie_global
+    call write_val(ui,i,je_global,k,forme,header)
    end do
-   write(ui,'()')
-   do j = je, js, -1
-    do i = is, ie
+   call write_string_master(ui, '')
+   do j = je_global, js_global, -1
+    do i = is_global, ie_global
      call write_val(ui,i,j,k,forme,header)
     end do
-    write(ui,'()')
+    call write_string_master(ui, '')
    end do
-   do i = is, ie
-    call write_val(ui,i,js,k,forme,header)
+   do i = is_global, ie_global
+    call write_val(ui,i,js_global,k,forme,header)
    end do
-   write(ui,'()')
+   call write_string_master(ui, '')
 
-   k = (ks+ke-1)/2
-   do i = is, ie
-    call write_val(ui,i,js,k,forme,header)
+   k = (ks_global+ke_global-1)/2
+   do i = is_global, ie_global
+    call write_val(ui,i,js_global,k,forme,header)
    end do
-   write(ui,'()')
-   do j = js, je
-    do i = is, ie
+   call write_string_master(ui, '')
+   do j = js_global, je_global
+    do i = is_global, ie_global
      call write_val(ui,i,j,k,forme,header)
     end do
-    write(ui,'()')
+    call write_string_master(ui, '')
    end do
-   do i = is, ie
-    call write_val(ui,i,je,k,forme,header)
+   do i = is_global, ie_global
+    call write_val(ui,i,je_global,k,forme,header)
    end do
 
   end if
 
-  close(ui)
+  call close_file(ui)
 
-  print*,"Outputted: ",trim(pltfile)
+  if (myrank==0) print*,"Outputted: ",trim(pltfile)
 
  end if
 
@@ -1393,18 +1385,19 @@ end subroutine add_column
 ! PURPOSE: To write a single row of values
 
 subroutine write_val(ui,i,j,k,forme,header)
-
  use settings,only:spn
  use physval
  use gravmod,only:grvphi,extgrv,totphi
-
- implicit none
+ use mpi_domain,only:is_my_domain
+ use io,only:write_string
 
  integer,intent(in):: ui,i,j,k
  character(len=*),intent(in):: forme, header(:)
  integer:: n, nn
 
 !-----------------------------------------------------------------------------
+
+ if (.not.is_my_domain(i,j,k)) return
 
  do n = 1, 50
   select case(header(n))
@@ -1439,7 +1432,7 @@ subroutine write_val(ui,i,j,k,forme,header)
   case('shock')!shock position
    call write_anyval(ui,forme,dble(shock(i,j,k)))
   case('aaa')!end of line
-   write(ui,'()')
+   call write_string(ui,'')
    exit
   case default!chemical composition
    do nn = 1, spn
@@ -1460,17 +1453,19 @@ end subroutine write_val
 ! PURPOSE: To write one value
 
 subroutine write_anyval(ui,forme,val)
-
+ use io, only:write_string
  integer,intent(in):: ui
  character(len=*),intent(in):: forme
  real(8),intent(in):: val
+ character(len=30):: str
 !-----------------------------------------------------------------------------
 
  if(abs(val)>=1d-99)then
-  write(ui,forme,advance='no')val
+  write(str,forme)val
  else
-  write(ui,forme,advance='no')0d0
+  write(str,forme)0d0
  end if
+ call write_string(ui,str,advance=.false.)
 
 return
 end subroutine write_anyval

--- a/src/output.f90
+++ b/src/output.f90
@@ -396,19 +396,13 @@ end subroutine sink_output
 
 ! PURPOSE: To output gridfile.bin and gridfile.dat
 subroutine write_grid
- use mpi_utils, only:myrank,nprocs,barrier_mpi
+ use mpi_utils, only:myrank,barrier_mpi
 
  if (myrank==0) then
   call write_grid_bin
-  if (nprocs==1) then
-    call write_grid_dat
-  else
-    write(*,'(60("*"))')
-    print*, 'WARNING: write_grid_dat not implemented for nprocs>1'
-    write(*,'(60("*"))')
-  end if
  end if
-
+ call barrier_mpi
+ call write_grid_dat
  call barrier_mpi
 
  return
@@ -429,7 +423,6 @@ subroutine write_grid_bin
 end subroutine write_grid_bin
 
 subroutine write_grid_dat
- ! TODO: MPI
  use settings
  use grid
  use mpi_utils, only: myrank
@@ -623,7 +616,7 @@ subroutine write_grid_dat
 
  call close_file(ui)
 
- print*,"Outputted: ",'gridfile.dat'
+ if (myrank==0) print*,"Outputted: ",'gridfile.dat'
 
 !othergrid--------------------------------------------------------------------
 

--- a/src/output.f90
+++ b/src/output.f90
@@ -427,7 +427,7 @@ subroutine write_grid_dat
  use grid
  use mpi_utils, only: myrank
  use mpi_domain, only: is_my_domain
- use io, only: write_string_master, open_file_write_ascii, close_file, write_string, write_string_master
+ use io, only: write_string_master, open_file_write_ascii, close_file, write_string_master
 
  character(len=50):: formhead,formval,formnum
  character(len=200) :: str
@@ -451,10 +451,7 @@ subroutine write_grid_dat
    call write_string_master(ui,str)
    j=js_global;k=ks_global
    do i = is_global, ie_global
-    if (is_my_domain(i,j,k)) then
-      write(str,formval) i,x1(i),dvol(i,j,k)
-      call write_string(ui, str)
-    end if
+    call write_my_grid_1d(ui,formval,i,x1(i),dvol,i,j,k)
    end do
 
   elseif(je_global>js_global)then
@@ -462,10 +459,7 @@ subroutine write_grid_dat
    call write_string_master(ui,str)
    i=is_global;k=ks_global
    do j = js_global, je_global
-    if (is_my_domain(i,j,k)) then
-      write(str,formval) j,x2(j),dvol(i,j,k)
-      call write_string(ui, str)
-    end if
+    call write_my_grid_1d(ui,formval,j,x2(j),dvol,i,j,k)
    end do
 
   elseif(ke_global>ks_global)then
@@ -473,10 +467,7 @@ subroutine write_grid_dat
    call write_string_master(ui,str)
    i=is_global;j=js_global
    do k = ks_global, ke_global
-    if (is_my_domain(i,j,k)) then
-      write(str,formval) k,x3(k),dvol(i,j,k)
-      call write_string(ui, str)
-    end if
+    call write_my_grid_1d(ui,formval,k,x3(k),dvol,i,j,k)
    end do
 
   end if
@@ -496,20 +487,14 @@ subroutine write_grid_dat
    if(crdnt==1.or.crdnt==2)then
     j=js_global-1
     do i = is_global, ie_global
-     if (is_my_domain(i,j,k)) then
-      write(str,formval) i,j,x1(i),xi2s,dvol(i,j,k)
-      call write_string(ui,str)
-     end if
+     call write_my_grid_2d(ui,formval,i,j,x1(i),xi2s,dvol,i,j,k)
     end do
     call write_string_master(ui, '')
    end if
 
    do j = js_global, je_global
     do i = is_global, ie_global
-     if (is_my_domain(i,j,k)) then
-      write(str,formval) i,j,x1(i),x2(j),dvol(i,j,k)
-      call write_string(ui,str)
-     end if
+     call write_my_grid_2d(ui,formval,i,j,x1(i),x2(j),dvol,i,j,k)
     end do
     call write_string_master(ui, '')
    end do
@@ -518,10 +503,7 @@ subroutine write_grid_dat
    if(crdnt==1.or.crdnt==2)then
     j=je_global+1
     do i = is_global, ie_global
-     if (is_my_domain(i,j,k)) then
-      write(str,formval) i,j,x1(i),xi2e,dvol(i,j,k)
-      call write_string(ui,str)
-     end if
+     call write_my_grid_2d(ui,formval,i,j,x1(i),xi2e,dvol,i,j,k)
     end do
     call write_string_master(ui, '')
    end if
@@ -534,17 +516,11 @@ subroutine write_grid_dat
 
     ! writing inner boundary for polar coordinates
     if(crdnt==1.or.crdnt==2) then
-     if (is_my_domain(is_global,j,k)) then
-      write(str,formval) is_global-1,k,xi1(is_global-1),x3(k),dvol(is_global,j,k)
-      call write_string(ui, str)
-     end if
+     call write_my_grid_2d(ui,formval,is_global-1,k,xi1(is_global-1),x3(k),dvol,is_global,j,k)
     end if
 
     do i = is_global, ie_global, outres
-     if (is_my_domain(i,j,k)) then
-      write(str,formval) i,k,xi1(i),x3(k),dvol(i,j,k)
-      call write_string(ui, str)
-     end if
+     call write_my_grid_2d(ui,formval,i,k,x1(i),x3(k),dvol,i,j,k)
     end do
     call write_string_master(ui, '')
    end do
@@ -556,10 +532,7 @@ subroutine write_grid_dat
    i=is_global
    do k = ks_global, ke_global
     do j = js_global, je_global
-     if (is_my_domain(i,j,k)) then
-      write(str,formval) j,k,x2(j),x3(k),dvol(i,j,k)
-      call write_string(ui,str)
-     end if
+     call write_my_grid_2d(ui,formval,j,k,x2(j),x3(k),dvol,i,j,k)
     end do
     call write_string_master(ui, '')
    end do
@@ -576,10 +549,7 @@ subroutine write_grid_dat
    k=ks_global-1
    do j = je_global, je_global
     do i = is_global, ie_global
-     if (is_my_domain(i,j,k)) then
-      write(str,formval) i,j,k,x1(i),x2(j),xi3(k),dvol(i,j,k)
-      call write_string(ui,str)
-     end if
+     call write_my_grid_3d(ui,formval,i,j,k,x1(i),x2(j),xi3(k),dvol,i,j,k)
     end do
     call write_string_master(ui, '')
    end do
@@ -588,10 +558,7 @@ subroutine write_grid_dat
   do k = ks_global, ke_global
    do j = je_global, je_global
     do i = is_global, ie_global
-     if (is_my_domain(i,j,k)) then
-      write(str,formval) i,j,k,x1(i),x2(j),x3(k),dvol(i,j,k)
-      call write_string(ui,str)
-     end if
+     call write_my_grid_3d(ui,formval,i,j,k,x1(i),x2(j),x3(k),dvol,i,j,k)
     end do
     call write_string_master(ui, '')
    end do
@@ -601,10 +568,7 @@ subroutine write_grid_dat
    k=ke_global
    do j = je_global, je_global
     do i = is_global, ie_global
-     if (is_my_domain(i,j,k)) then
-      write(str,formval) i,j,k,x1(i),x2(j),xi3(k),dvol(i,j,k)
-      call write_string(ui,str)
-     end if
+     call write_my_grid_3d(ui,formval,i,j,k,x1(i),x2(j),xi3(k),dvol,i,j,k)
     end do
     call write_string_master(ui, '')
    end do
@@ -639,55 +603,37 @@ subroutine write_grid_dat
    k = ks_global
 
    do i = is_global, ie_global
-    if (is_my_domain(i,je_global,k)) then
-     write(str,formval) i,-je_global-1,x1(i),-xi2(je_global),dvol(i,je_global,k)
-     call write_string(ui,str)
-    end if
+    call write_my_grid_2d(ui,formval,i,-je_global-1,x1(i),-xi2(je_global),dvol,i,je_global,k)
    end do
    call write_string_master(ui, '')
 
    do j = je_global, js_global, -1
     do i = is_global, ie_global
-     if (is_my_domain(i,j,k)) then
-      write(str,formval) i,-j,x1(i),-x2(j),dvol(i,j,k)
-      call write_string(ui,str)
-     end if
+     call write_my_grid_2d(ui,formval,i,-j,x1(i),-x2(j),dvol,i,j,k)
     end do
     call write_string_master(ui, '')
    end do
 
    do i = is_global, ie_global
-    if (is_my_domain(i,js_global,k)) then
-     write(str,formval) i,0,x1(i),-xi2(js_global-1),dvol(i,js_global,k)
-     call write_string(ui,str)
-    end if
+    call write_my_grid_2d(ui,formval,i,0,x1(i),-xi2(js_global-1),dvol,i,js_global,k)
    end do
    call write_string_master(ui, '')
 
    k = (ks_global+ke_global-1)/2
    do i = is_global, ie_global
-    if (is_my_domain(i,js_global,k)) then
-     write(str,formval) i,0,x1(i),xi2(js_global-1),dvol(i,js_global,k)
-     call write_string(ui,str)
-    end if
+    call write_my_grid_2d(ui,formval,i,0,x1(i),xi2(js_global-1),dvol,i,js_global,k)
    end do
    call write_string_master(ui, '')
 
    do j = js_global, je_global
     do i = is_global, ie_global
-     if (is_my_domain(i,j,k)) then
-      write(str,formval) i,j,x1(i),x2(j),dvol(i,j,k)
-      call write_string(ui,str)
-     end if
+     call write_my_grid_2d(ui,formval,i,j,x1(i),x2(j),dvol,i,j,k)
     end do
     call write_string_master(ui, '')
    end do
 
    do i = is_global, ie_global
-    if (is_my_domain(i,je_global,k)) then
-     write(str,formval) i,je_global+1,x1(i),xi2(je_global),dvol(i,je_global,k)
-     call write_string(ui,str)
-    end if
+    call write_my_grid_2d(ui,formval,i,je_global+1,x1(i),xi2(je_global),dvol,i,je_global,k)
    end do
 
   end if
@@ -1521,5 +1467,53 @@ subroutine write_anyval(ui,forme,val)
 
 return
 end subroutine write_anyval
+
+subroutine write_my_grid_1d(ui,form,ii,x1,dvol,i,j,k)
+  use mpi_domain, only:is_my_domain
+  use io, only:write_string
+  integer, intent(in) :: ui,i,j,k,ii
+  character(len=*), intent(in) :: form
+  real(8), intent(in) :: x1
+  real(8), allocatable, intent(in) :: dvol(:,:,:)
+  character(len=100) :: str
+
+  if (is_my_domain(i,j,k)) then
+    write(str,form) ii,x1,dvol(i,j,k)
+    call write_string(ui,str)
+  end if
+
+end subroutine write_my_grid_1d
+
+subroutine write_my_grid_2d(ui,form,ii,jj,x1,x2,dvol,i,j,k)
+  use mpi_domain, only:is_my_domain
+  use io, only:write_string
+  integer, intent(in) :: ui,i,j,k,ii,jj
+  character(len=*), intent(in) :: form
+  real(8), intent(in) :: x1,x2
+  real(8), allocatable, intent(in) :: dvol(:,:,:)
+  character(len=200) :: str
+
+  if (is_my_domain(i,j,k)) then
+    write(str,form) ii,jj,x1,x2,dvol(i,j,k)
+    call write_string(ui,str)
+  end if
+
+end subroutine write_my_grid_2d
+
+subroutine write_my_grid_3d(ui,form,ii,jj,kk,x1,x2,x3,dvol,i,j,k)
+  use mpi_domain, only:is_my_domain
+  use io, only:write_string
+  integer, intent(in) :: ui,i,j,k,ii,jj,kk
+  character(len=*), intent(in) :: form
+  real(8), intent(in) :: x1,x2,x3
+  real(8), allocatable, intent(in) :: dvol(:,:,:)
+  character(len=300) :: str
+
+  if (is_my_domain(i,j,k)) then
+    write(str,form) ii,jj,kk,x1,x2,x3,dvol(i,j,k)
+    call write_string(ui,str)
+  end if
+
+end subroutine write_my_grid_3d
 
 end module output_mod

--- a/src/output.f90
+++ b/src/output.f90
@@ -756,7 +756,7 @@ subroutine write_plt
  integer:: i,j,k,n,ui,columns
 
 ! Calculate gravitational potential here if spherical
- if(gravswitch==1) call gravpot1d    ! TODO: MPI
+ if(gravswitch==1) call gravpot1d
 ! Calculate shock position if required
  if(write_shock)call shockfind
 

--- a/work/Makefile
+++ b/work/Makefile
@@ -37,7 +37,7 @@ BIN_DIR = $(HORMONE_DIR)/bin
 TARGET = hormone
 
 # compile modules that are being depended on first
-MOD = mpi_utils.F90 modules.f90 profiler.f90 utils.f90 conserve.f90 ionization.f90 eos.f90 miccg.f90 fluxlimiter.f90 hlldflux.f90 dirichlet.f90 particles.f90 radiation.f90 cooling.f90 sinks.f90 composition.f90 star.f90 shockfind.f90 io.F90 output.f90 smear.f90 input.f90 setup.f90 readbin.f90 tests.f90 restart.f90 fluxboundary.f90 rungekutta.f90 timestep.f90 gridset.f90
+MOD = mpi_utils.F90 modules.f90 profiler.f90 utils.f90 conserve.f90 ionization.f90 eos.f90 miccg.f90 fluxlimiter.f90 hlldflux.f90 dirichlet.f90 particles.f90 radiation.f90 cooling.f90 sinks.f90 mpi_domain.F90 composition.f90 star.f90 shockfind.f90 io.F90 output.f90 smear.f90 input.f90 setup.f90 readbin.f90 tests.f90 restart.f90 fluxboundary.f90 rungekutta.f90 timestep.f90 gridset.f90
 
 # Initial condition routines should be compiled before initialcondition.f90
 INI = eostest.f90 shocktube.f90 orszagtang.f90 sedov.f90 KHtests.f90 star_init.f90 rsg.f90 agndisk.f90 windtunnel.f90 rad_box.f90 stellarcollision.f90 modify.f90 iotest.f90


### PR DESCRIPTION
This PR implements parallel IO for the ascii output files created by `write_grid_dat` and `write_plt`. As part of this, we also parallelised the `gravpot1d` routine.

The subroutines function much the same as before, looping over the global indices, and only writing to the file if they "own" the current set of indices `i,j,k`

We've also simplified the wrapper `open_file_write` routine and added a separate `open_file_write_ascii`