### PR TITLE
Fix divide by zero errors in test suite

### DIFF
--- a/src/star_init.f90
+++ b/src/star_init.f90
@@ -56,6 +56,10 @@ subroutine star_init
           species(1:spn) )
  species(1:spn) = spc_list(1:spn)
 
+ ! Not all of the species in the list may be in the mesa file
+ ! so they need to initialised to zero to avoid errors
+ spc = 0d0
+
  call read_mesa(mesafile,r,m,rho,pres,comp,comp_list)
 
  mass = m(size(m)-1)

--- a/src/star_init.f90
+++ b/src/star_init.f90
@@ -59,6 +59,7 @@ subroutine star_init
  ! Not all of the species in the list may be in the mesa file
  ! so they need to initialised to zero to avoid errors
  spc = 0d0
+ spc_bg = 0d0
 
  call read_mesa(mesafile,r,m,rho,pres,comp,comp_list)
 


### PR DESCRIPTION
Fixes #45 

`fe56` is specified in the file `extras_star`, but is not present as a column in the MESA data `sun_profile.data`. As a side note, it is present as `co56_fe56` but this doesn't match the string so it is never used.

This results in the fe56 abundance being uninitialised in the `spc` array. Although unsafe, in gfortran this always seems to be fine, but not in the latest version of `ifx`.

This is fixed by setting `spc` and `spc_bg` to zero before applying the interpolated values from the MESA data.