### PR TITLE
Clean MPI exit

### DIFF
--- a/src/hormone.f90
+++ b/src/hormone.f90
@@ -195,7 +195,7 @@ program hormone
 
   if(is_test) then
     call test(passed)
-    if (.not. passed) error stop 1
+    if (.not. passed) call stop_mpi(1)
   endif
 
   call finalize_mpi

--- a/src/iotest.f90
+++ b/src/iotest.f90
@@ -293,7 +293,7 @@ module iotest_mod
       if (numerr > 0) then
         print*, 'Number of errors = ',numerr
         print*, 'Test failed'
-        error stop 1
+        call stop_mpi(1)
       else
         call cleanup_files(tn=123, time=456.d0)
         print*, 'Test passed'

--- a/src/mpi_utils.F90
+++ b/src/mpi_utils.F90
@@ -97,7 +97,7 @@ module mpi_utils
 #ifdef MPI
     call finalize_mpi
 #endif
-    if (myrank == 0 .and. code /= 0) then
+    if (myrank==0 .and. code/=0) then
       error stop code
     endif
 

--- a/src/mpi_utils.F90
+++ b/src/mpi_utils.F90
@@ -92,4 +92,16 @@ module mpi_utils
 #endif
   end subroutine
 
+  subroutine stop_mpi(code)
+    integer, intent(in) :: code
+#ifdef MPI
+    call finalize_mpi
+#endif
+    if (myrank == 0 .and. code /= 0) then
+      error stop code
+    endif
+
+    stop
+  end subroutine
+
 end module mpi_utils


### PR DESCRIPTION
When `stop` is called with a non-zero exit code, MPI raises many multi-line errors - one per MPI task. For large numbers of MPI tasks, this results in a lot of noise that can obscure the actual error.

This PR adds the subroutine `mpi_stop` which calls `MPI_FINALIZE` before stopping with an exit code, resulting in a cleaner output. Importantly, the exit code is still preserved, which is necessary for the test suite.

Existing `stop` calls with a non-zero exit code have been replaced, but regular `stop`s have been left unchanged.