### PR TITLE
Make masscoordinate function MPI-safe

### DIFF
--- a/src/utils.f90
+++ b/src/utils.f90
@@ -318,7 +318,7 @@ subroutine masscoordinate
 !$omp parallel
  do i = is_global, ie_global
   shellmass = 0d0
-  if (is_global <= i .and. i <= ie_global) then
+  if (is<=i .and. i<=ie) then
 !$omp do private(j,k) reduction(+:shellmass)
    do k = ks, ke
     do j = js, je

--- a/src/utils.f90
+++ b/src/utils.f90
@@ -327,8 +327,8 @@ subroutine masscoordinate
    end do
   endif
 !$omp end do
-  call allreduce_mpi('sum',shellmass)
 !$omp single
+  call allreduce_mpi('sum',shellmass)
   mc(i) = mc(i-1) + fac*shellmass
 !$omp end single
  end do

--- a/src/utils.f90
+++ b/src/utils.f90
@@ -325,8 +325,8 @@ subroutine masscoordinate
      shellmass = shellmass + d(i,j,k)*dvol(i,j,k)
     end do
    end do
-  endif
 !$omp end do
+  end if
 !$omp single
   call allreduce_mpi('sum',shellmass)
   mc(i) = mc(i-1) + fac*shellmass


### PR DESCRIPTION
This makes the masscoordinate function MPI safe.

The outer loop iterates over all radial cells `i = is_global, ie_global`. If the MPI task contains cells in that shell, it adds to `shellmass`. Otherwise, `shellmass` remains zero.

A call to `allreduce_mpi` sums up contributions to that shell from all MPI tasks. MPI tasks which do not contain that shell contribute zero. Then `shellmass` is added to the array `mc`.