### PR TITLE
Add eruption subroutine to reproduce Owocki+2019

### DIFF
--- a/para/extras_eruption
+++ b/para/extras_eruption
@@ -1,0 +1,16 @@
+! Model parameters for eruption
+
+! mesafile: Name of MESA profile file to be read.
+! spc_list: List of all elements to be tracked in the simulation.
+! Eexp: Explosion energy in units of stellar binding energy
+! inj_in: Inner edge of energy injection region (Rsun)
+! inj_out: Outer edge of energy injection region (Rsun)
+
+&erupcon
+ mesafile='../tests/100Msunprofile.data'
+ spc_list = ''
+ Eexp = 0.5d0
+ inj_in = 0d0
+ inj_out = 5.5d0
+/
+! Do not delete this blank line

--- a/para/parameters_base
+++ b/para/parameters_base
@@ -14,7 +14,7 @@
 ! dt_out : Interval for output time (only when outstyle=1)
 ! tn_out : Interval for output timesteps (only when outstyle=2)
 ! tn_evo : Interval for evo file output (only when write_evo=.true.)
-! dt_unit : Give name of dt_unit (current options are 'ms,'ns,'s','hr','d','yr')
+! dt_unit : Give name of dt_unit (current options are 'ns,'ms,'s','min','ks','hr','d','yr')
 ! sigfig : How many significant figures in output values
 ! outres : Resolution of output grid (1 means output everything, 2 means every 2 grid points, etc)
 ! write_other_vel : Set to .true. if 2.5D
@@ -22,11 +22,12 @@
 ! write_evo : Output evofile
 ! write_other_slice : Output an alternative slice for 3D
 ! write_temp : Output temperature (only relevant for eostype=0)
+! write_mc : Output mass coordinates (only relevant for crdnt=2)
 &out_con  outstyle=1 endstyle=1
           tnlim=0 t_end=0d0 dt_out=1d0 tn_out=1 tn_evo=10
           dt_unit='s' sigfig=7 outres=1
 	  write_other_vel =.false. write_shock =.false. write_evo=.false.
-	  write_other_slice=.false. write_temp = .false. /
+	  write_other_slice=.false. write_temp = .false. write_mc=.false. /
 
 ! eostype : 0='ideal gas'
 !	    1='ideal gas + radiation pressure'

--- a/para/parameters_eruption
+++ b/para/parameters_eruption
@@ -1,0 +1,21 @@
+----------------------------- parameters --------------------------------
+
+&gridcon  xi1s=0d0 xi1e=2.4d13 
+	  is=1 ie=3000 js=1 je=1 ks=1 ke=1
+	  imesh=1 jmesh=0 kmesh=0
+	  x1min=2d9 x2min=0 x3min=0d0 /
+
+&out_con  outstyle=1 endstyle=1
+          tnlim=500000 t_end=1d6 dt_out=1.d3 tn_out=10000000
+          dt_unit='s' sigfig=7 outres=1
+	  write_mc=.true. /
+
+&eos_con eostype = 1 eoserr=1d-15 compswitch=1 muconst=0.62d0 spn=8 /
+
+&simucon  crdnt=2 /
+
+&bouncon  bc1is=1 bc1os=2 bc2is=1 bc2os=1 bc3is=0 bc3os=0
+	  bc1iv=1 bc1ov=2 bc2iv=1 bc2ov=1 bc3iv=0 bc3ov=0 eq_sym=.false. /
+
+&gravcon gravswitch=1
+	 gis=1 gie=1 gjs=1 gje=1 gks=1 gke=1 /

--- a/src/checksetup.f90
+++ b/src/checksetup.f90
@@ -182,7 +182,7 @@ subroutine checksetup
   t_end = t_end*dt_unit_in_sec
 
 ! Spherical composition only for spherical coordinates
-  if(compswitch==1.and.crdnt/=2)then
+  if(compswitch==1.and.(crdnt/=2.or.max(je-js,ke-ks)>0))then
    print *,"compswitch is not consistent with coordinate", compswitch
    stop
   end if

--- a/src/checksetup.f90
+++ b/src/checksetup.f90
@@ -36,6 +36,7 @@ subroutine checksetup
   end if
   if(dim/=2) write_other_vel = .false.
   if(dim/=3) write_other_slice = .false.
+  if(crdnt/=2) write_mc = .false.
 
 ! Count number of equations
   ufnmax = 0
@@ -162,6 +163,8 @@ subroutine checksetup
    dt_unit_in_sec = 3600*24d0
   case('hr')
    dt_unit_in_sec = 3600d0
+  case('ks')
+   dt_unit_in_sec = 1000d0
   case('min')
    dt_unit_in_sec = 60d0
   case('s')

--- a/src/composition.f90
+++ b/src/composition.f90
@@ -54,15 +54,17 @@ subroutine meanmolweight
 
  case(2) composition_type ! for composition advection
 !$omp parallel
+  if(eostype<=1)then
 !$omp do private(i,j,k) collapse(3)
-  do k = ks, ke
-   do j = js, je
-    do i = is, ie
-     imu(i,j,k) = get_imu(spc(1:2,i,j,k))
+   do k = ks, ke
+    do j = js, je
+     do i = is, ie
+      imu(i,j,k) = get_imu(spc(1:2,i,j,k))
+     end do
     end do
    end do
-  end do
 !$omp end do
+  end if
 !$omp do private(i,j,k)
   do k = ks, ke
    do j = js-2, js-1

--- a/src/composition.f90
+++ b/src/composition.f90
@@ -58,7 +58,7 @@ subroutine meanmolweight
   do k = ks, ke
    do j = js, je
     do i = is, ie
-     imu(i,j,k) = get_imu(spc(1:2,i,j,k))!0.25d0*(6d0*spc(1,i,j,k)+spc(2,i,j,k)+2d0)
+     imu(i,j,k) = get_imu(spc(1:2,i,j,k))
     end do
    end do
   end do

--- a/src/eruption.f90
+++ b/src/eruption.f90
@@ -1,0 +1,171 @@
+module eruption_mod
+ implicit none
+
+contains
+
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+!
+!                         SUBROUTINE ERUPTION
+!
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+! PURPOSE: To simulate eruptions of stars (Owocki+2019)
+
+subroutine eruption
+
+ use settings,only:compswitch,spn,extrasfile,is_test,eostype
+ use constants,only:G,rsun
+ use grid
+ use physval
+ use input_mod
+ use star_mod
+ use pressure_mod,only:eos_e,eos_p
+ use composition_mod,only:meanmolweight
+ use gravmod,only:mc
+
+ character(len=100):: mesafile
+ real(8),allocatable,dimension(:):: r,m,rho,pres
+ real(8),allocatable,dimension(:,:):: comp
+ character(len=10),allocatable:: comp_list(:)
+ character(len=10)::spc_list(1:1000)
+ integer::i,j,k,nn,sn,istat,i_inj_in,i_inj_out
+ real(8)::dbg,mass,radius,spc_bg(1:spn),Eexp,Ebind,ene,Temp,&
+          inj_in,inj_out,imu_local,ecell
+
+!-----------------------------------------------------------------------------
+
+ namelist /erupcon/ mesafile,spc_list,Eexp,inj_in,inj_out
+
+ spc_list='aaa'
+ if(is_test) extrasfile='../para/extras_eruption'
+
+! Specify input file, elements you want to track, and a softening length
+ open(newunit=nn,file=extrasfile,status='old',iostat=istat)
+ if(istat/=0)call error_extras('eruption',extrasfile)
+ read(nn,NML=erupcon,iostat=istat)
+ if(istat/=0)call error_nml('eruption',extrasfile)
+ close(nn)
+
+! Re-count spn based on spc_list and reallocate relevant arrays
+ spn=-1
+ do nn = 1, 1000
+  spn = spn + 1
+  if(spc_list(nn)=='aaa')exit
+ end do
+ deallocate(spc,spcorg,dspc,spcflx,species)
+ allocate(spc    (1:spn,is-2:ie+2,js-2:je+2,ks-2:ke+2), &
+          spcorg (1:spn,is:ie,js:je,ks:ke), &
+          dspc   (1:spn,is-1:ie+1,js-1:je+1,ks-1:ke+1,1:3), &
+          spcflx (1:spn,is-1:ie+1,js-1:je+1,ks-1:ke+1,1:3), &
+          species(1:spn) )
+ species(1:spn) = spc_list(1:spn)
+
+ ! Not all of the species in the list may be in the mesa file
+ ! so they need to initialised to zero to avoid errors
+ spc = 0d0
+ spc_bg = 0d0
+
+ select case (compswitch)
+ case(1)
+  call read_mesa(mesafile,r,m,rho,pres,mu=mudata)
+ case(2)
+  call read_mesa(mesafile,r,m,rho,pres,comp=comp,comp_list=comp_list)
+ case default
+  call read_mesa(mesafile,r,m,rho,pres)
+ end select
+
+ mass = m(size(m)-1)
+ radius = r(size(r)-1)
+ dbg = rho(size(rho)-1)*1d-3
+
+! Compute binding energy
+ Ebind = 0d0
+ do i = 2, size(rho)-1
+  ! Get local internal energy
+  select case (eostype)
+  case(1)
+   imu_local = 1d0/mudata(i,1)
+   ene = eos_e(rho(i),pres(i),Temp,imu_local)
+  case(2)
+   ene = eos_e(rho(i),pres(i),Temp,imu_local,X=comp(1,i),Y=comp(2,i))
+  case default
+   ene = eos_e(rho(i),pres(i),Temp,imu_local)
+  end select
+  Ebind = Ebind - G*m(i-1)*(m(i)-m(i-1)) / r(i-1) + ene*(m(i)-m(i-1))
+ end do
+
+! Set explosion energy to fraction of binding energy
+ Eexp = - Ebind * Eexp
+
+! Use outermost composition as the ambient gas composition
+ do nn = 1, spn-1
+  do sn = 1, size(comp_list)
+   if(trim(comp_list(sn))==trim(species(nn)))then
+    spc_bg(nn) = comp(sn,size(rho)-1)
+    exit
+   end if
+  end do
+ end do
+ spc_bg(spn) = 1d0-sum(spc_bg(1:spn-1))
+
+! Place the star at the origin
+ call set_star_sph_grid(r,m,rho,pres,comp,comp_list)
+
+! Attach a wind-like atmosphere
+ do k = ks, ke
+  do j = js, je
+   do i = is, ie
+    if(d(i,j,k)<0d0)then
+     d(i,j,k) = dbg*(radius/x1(i))**2
+     if(compswitch==2)spc(1:spn,i,j,k) = spc_bg(1:spn)
+    end if
+   end do
+  end do
+ end do
+
+! Re-calculate hydrostatic equilibrium
+ call meanmolweight
+ do k = ks, ke
+  do j = js, je
+   do i = ie, is, -1
+    p(i,j,k) = p(i+1,j,k)+G*mc(i)*d(i,j,k)/xi1(i)**2*dx1(i)
+    eint(i,j,k) = eos_e(d(i,j,k),p(i,j,k),T(i,j,k),imu(i,j,k))
+   end do
+  end do
+ end do
+
+! Find inner and outer boundary
+ i_inj_in = is-1
+ do i = is, ie
+  if(xi1(i)>inj_in*rsun.and.i_inj_in<is)then
+   i_inj_in = i
+  end if
+  if(xi1(i)>inj_out*rsun.or.xi1(i)>r(size(r)-1))then
+   i_inj_out = i
+   exit
+  end if
+ end do
+
+ ecell = Eexp / (mc(i_inj_out)-mc(i_inj_in-1))
+
+ do k = ks, ke
+  do j = js, je
+   do i = i_inj_in, i_inj_out
+    eint(i,j,k) = eint(i,j,k) + ecell*d(i,j,k)
+    select case(eostype)
+    case(0,1)
+     p(i,j,k) = eos_p(d(i,j,k),eint(i,j,k),T(i,j,k),imu(i,j,k))
+    case(2)
+     p(i,j,k) = eos_p(d(i,j,k),eint(i,j,k),T(i,j,k),imu(i,j,k),&
+                      spc(1,i,j,k),spc(2,i,j,k))
+    case default
+     stop 'Error in eruption.f90; eostype is wrong'
+    end select
+   end do
+  end do
+ end do
+
+return
+end subroutine eruption
+
+end module eruption_mod

--- a/src/initialcondition.f90
+++ b/src/initialcondition.f90
@@ -23,6 +23,7 @@ subroutine initialcondition
  use eostest_mod
  use shocktube_mod
  use sedov_mod
+ use eruption_mod
  use orszagtang_mod
  use KHinstability_mod
  use rad_box_mod
@@ -52,6 +53,9 @@ subroutine initialcondition
 
   case('sedov_default','sedov_other')
    call sedov
+
+  case('eruption')
+   call eruption
 
   case('orszagtang_xy','orszagtang_yz','orszagtang_xz')
    call orszagtang

--- a/src/input.f90
+++ b/src/input.f90
@@ -11,20 +11,21 @@ module input_mod
 
 ! PURPOSE: To read MESA file
 
-subroutine read_mesa(mesafile,r,m,rho,pres,comp,comp_list)
+subroutine read_mesa(mesafile,r,m,rho,pres,mu,comp,comp_list)
 
  use constants,only:msun,rsun
+ use composition_mod,only:get_imu
 
  implicit none
 
  character(len=100),intent(in):: mesafile
  character(len=30),allocatable::header(:),dum(:)
  real(8),allocatable,dimension(:),intent(out):: r, m, rho, pres
- real(8),allocatable,dimension(:,:),intent(out),optional:: comp
+ real(8),allocatable,dimension(:,:),intent(out),optional:: mu, comp
  character(len=10),allocatable,intent(out),optional::comp_list(:)
- real(8),allocatable,dimension(:,:):: dat
+ real(8),allocatable,dimension(:,:):: dat,Xfrac
  character(len=10000):: dumc
- integer:: nn,ui, i,j, lines, rows, nrel, nel,istat
+ integer:: nn,ui, i,j, lines, columns, nrel, nel,istat
  character(len=10),allocatable:: element_list(:)
 
 
@@ -62,42 +63,40 @@ subroutine read_mesa(mesafile,r,m,rho,pres,comp,comp_list)
   print'(3a)',"mesafile='",trim(mesafile),"'"
   stop
  end if
- read(ui,'()')
- read(ui,'()')
+ read(ui,'()');read(ui,'()')
  read(ui,*) lines, lines
- read(ui,'()')
- read(ui,'()')
+ read(ui,'()');read(ui,'()')
  read(ui,'(a)') dumc
 
-! counting rows
+! counting columns
  allocate(dum(500)) ; dum = 'aaa'
  read(dumc,*,end=101) dum
 101 do i = 1, 500
   if(dum(i)=='aaa')then
-   rows = i - 1
+   columns = i - 1
    exit
   end if
  end do
 
- allocate(header(1:rows),dat(1:lines,1:rows))
- header(1:rows) = dum(1:rows)
+ allocate(header(1:columns),dat(1:lines,1:columns))
+ header(1:columns) = dum(1:columns)
  deallocate(dum)
 
 ! find relevant chemical elements in the headers
  if(present(comp))then
   nel = 0
   do j = 1, nrel
-   do i = 1, rows
+   do i = 1, columns
     if(trim(header(i))==trim(element_list(j)))then
      nel = nel + 1 ! first count how many elements
      exit
     end if
    end do
   end do
-  allocate(comp_list(nel))
+  allocate(comp_list(nel),comp(1:nel,0:lines))
   nn = 1
   element_loop: do j = 1, nrel
-   do i = 1, rows
+   do i = 1, columns
     if(trim(header(i))==trim(element_list(j)))then
      comp_list(nn) = trim(header(i))
      nn = nn + 1
@@ -109,18 +108,48 @@ subroutine read_mesa(mesafile,r,m,rho,pres,comp,comp_list)
  end if
 
  do i = 1, lines
-  read(ui,*) dat(lines-i+1,1:rows)
+  read(ui,*) dat(lines-i+1,1:columns)
  end do
 
- allocate(m(0:lines),r(0:lines),rho(0:lines),pres(0:lines),comp(1:nel,0:lines))
- do i = 1, rows
-  if(trim(header(i))=='mass') m(1:lines) = dat(1:lines,i) * msun
-  if(trim(header(i))=='density') rho(1:lines) = dat(1:lines,i)
-  if(trim(header(i))=='rho') rho(1:lines) = dat(1:lines,i)
-  if(trim(header(i))=='radius_cm') r(1:lines) = dat(1:lines,i)
-  if(trim(header(i))=='radius') r(1:lines) = dat(1:lines,i) * rsun
-  if(trim(header(i))=='logR') r(1:lines) = 10**dat(1:lines,i) * rsun
-  if(trim(header(i))=='pressure') pres(1:lines) = dat(1:lines,i)
+ allocate(m(0:lines))
+ allocate(r,rho,pres,mold=m)
+ if(present(mu))then
+  allocate(mu(0:lines,0:1))
+  allocate(Xfrac,mold=mu)
+  mu(1,0) = -1d0
+ end if
+
+ do i = 1, columns
+  select case(trim(header(i)))
+  case('mass')
+   m(1:lines) = dat(1:lines,i) * msun
+  case('logM','log_mass')
+   m(1:lines) = 10d0**dat(1:lines,i) * msun
+  case('density','rho')
+   rho(1:lines) = dat(1:lines,i)
+  case('logRho')
+   rho(1:lines) = 10d0**dat(1:lines,i)
+  case('radius_cm')
+   r(1:lines) = dat(1:lines,i)
+  case('radius_km')
+   r(1:lines) = dat(1:lines,i) * 1d5
+  case('radius')
+   r(1:lines) = dat(1:lines,i) * rsun
+  case('logR')
+   r(1:lines) = 10d0**dat(1:lines,i) * rsun
+  case('logR-cm')
+   r(1:lines) = 10d0**dat(1:lines,i)
+  case('pressure')
+   pres(1:lines) = dat(1:lines,i)
+  case('logP')
+   pres(1:lines) = 10d0**dat(1:lines,i)
+  case('mu')
+   if(present(mu)) mu(1:lines,1) = dat(1:lines,i)
+  case('h1','x_mass_fraction_H')
+   if(present(mu)) Xfrac(1:lines,0) = dat(1:lines,i)
+  case('he4','y_mass_fraction_He')
+   if(present(mu)) Xfrac(1:lines,1) = dat(1:lines,i)
+  end select
   if(present(comp))then
    do j = 1, nel
     if(trim(header(i))==trim(comp_list(j))) comp(j,1:lines) = dat(1:lines,i)
@@ -130,11 +159,21 @@ subroutine read_mesa(mesafile,r,m,rho,pres,comp,comp_list)
 
  close(ui)
 
+! Set central values
  r(0) = 0d0
  m(0) = 0d0
  rho(0) = rho(1)
  pres(0) = pres(1)
- comp(:,0) = comp(:,1)
+ if(present(mu))then
+  if(mu(1,0)<0d0)then ! compute mu from X and Y if not outputted
+   do i = 1, lines
+    mu(i,1) = 1d0/get_imu(Xfrac(i,0:1))
+   end do
+  end if
+  mu(:,0) = m(:)
+  mu(0,1) = mu(1,1)
+ end if
+ if(present(comp))comp(:,0) = comp(:,1)
 
 return
 end subroutine read_mesa

--- a/src/modules.f90
+++ b/src/modules.f90
@@ -28,8 +28,9 @@ module settings
  logical:: solve_i, solve_j, solve_k
  logical:: include_extgrv, include_particles, include_cooling, mag_on
  logical:: include_extforce, include_sinks, is_test
- logical:: write_other_vel, write_shock, grav_init_other, grav_init_relax, write_evo
- logical:: write_other_slice, write_temp
+ logical:: write_other_vel, write_shock, write_evo, write_other_slice
+ logical:: write_temp, write_mc
+ logical:: grav_init_other, grav_init_relax
  character(len=30):: flux_limiter, simtype
  character(len=50):: parafile,extrasfile
 

--- a/src/output.f90
+++ b/src/output.f90
@@ -1353,6 +1353,9 @@ subroutine get_header(header,columns)
 ! Output shock position if write_shock=.true.
  if(write_shock)call add_column('shock',columns,header)
 
+! Output mass coordinate if write_mc=.true.
+ if(write_mc)call add_column('mc',columns,header)
+
 return
 end subroutine get_header
 
@@ -1387,7 +1390,7 @@ end subroutine add_column
 subroutine write_val(ui,i,j,k,forme,header)
  use settings,only:spn
  use physval
- use gravmod,only:grvphi,extgrv,totphi
+ use gravmod,only:grvphi,extgrv,totphi,mc
  use mpi_domain,only:is_my_domain
  use io,only:write_string
 
@@ -1431,6 +1434,8 @@ subroutine write_val(ui,i,j,k,forme,header)
    call write_anyval(ui,forme,1d0/imu(i,j,k))
   case('shock')!shock position
    call write_anyval(ui,forme,dble(shock(i,j,k)))
+  case('mc')!mass coordinate
+   call write_anyval(ui,forme,mc(i))
   case('aaa')!end of line
    call write_string(ui,'')
    exit

--- a/src/rsg.f90
+++ b/src/rsg.f90
@@ -62,7 +62,7 @@ subroutine redsupergiant
  species(1:spn) = spc_list(1:spn)
 
 ! Read MESA file
- call read_mesa(mesafile,r,m,rho,pres,comp,comp_list)
+ call read_mesa(mesafile,r,m,rho,pres,comp=comp,comp_list=comp_list)
 
  mass = m(size(m)-1)
  dbg = rho(size(rho)-1)*1d-5

--- a/src/setup.f90
+++ b/src/setup.f90
@@ -109,6 +109,8 @@ subroutine read_default
   filename='../para/parameters_othershock_z'
  case('sedov_default','sedov_other')
   filename='../para/parameters_sedov_default'
+ case('eruption')
+  filename='../para/parameters_eruption'
  case('KHinstability')
   filename='../para/parameters_KHinstability'
  case('rad_box')
@@ -165,7 +167,7 @@ subroutine read_parameters(filename)
                     fmr_max, fmr_lvl
  namelist /out_con/ outstyle, endstyle, tnlim, t_end, dt_out, tn_out, tn_evo,&
                     dt_unit, sigfig, outres, write_other_vel, write_shock, &
-                    write_evo, write_other_slice, write_temp
+                    write_evo, write_other_slice, write_temp, write_mc
  namelist /eos_con/ eostype, gamma, eoserr, compswitch, muconst, spn
  namelist /simucon/ crdnt, courant, rktype, mag_on, flux_limiter, alpha9wave,&
                     include_cooling, include_extforce, extrasfile

--- a/src/star_init.f90
+++ b/src/star_init.f90
@@ -61,7 +61,7 @@ subroutine star_init
  spc = 0d0
  spc_bg = 0d0
 
- call read_mesa(mesafile,r,m,rho,pres,comp,comp_list)
+ call read_mesa(mesafile,r,m,rho,pres,comp=comp,comp_list=comp_list)
 
  mass = m(size(m)-1)
  radius = r(size(r)-1)

--- a/src/stellarcollision.f90
+++ b/src/stellarcollision.f90
@@ -74,7 +74,7 @@ subroutine stellarcollision
  end if
 
 ! Read MESA file
- call read_mesa(mesafile,r,m,rho,pres,comp,comp_list)
+ call read_mesa(mesafile,r,m,rho,pres,comp=comp,comp_list=comp_list)
 
  mass = m(size(m)-1)
  dbg = rho(size(rho)-1)*1d-5

--- a/work/Makefile
+++ b/work/Makefile
@@ -39,7 +39,7 @@ TARGET = hormone
 MOD = mpi_utils.F90 modules.f90 profiler.f90 utils.f90 conserve.f90 ionization.f90 eos.f90 miccg.f90 fluxlimiter.f90 hlldflux.f90 dirichlet.f90 particles.f90 radiation.f90 cooling.f90 sinks.f90 mpi_domain.F90 composition.f90 star.f90 shockfind.f90 io.F90 output.f90 smear.f90 input.f90 setup.f90 readbin.f90 tests.f90 restart.f90 fluxboundary.f90 rungekutta.f90 timestep.f90 gridset.f90 gravbound.f90 gravity_hyperbolic.f90 gravity_miccg.f90
 
 # Initial condition routines should be compiled before initialcondition.f90
-INI = eostest.f90 shocktube.f90 orszagtang.f90 sedov.f90 KHtests.f90 star_init.f90 rsg.f90 polytrope.f90 agndisk.f90 windtunnel.f90 rad_box.f90 stellarcollision.f90 modify.f90 iotest.f90
+INI = eostest.f90 shocktube.f90 orszagtang.f90 sedov.f90 eruption.f90 KHtests.f90 star_init.f90 rsg.f90 polytrope.f90 agndisk.f90 windtunnel.f90 rad_box.f90 stellarcollision.f90 modify.f90 iotest.f90
 
 MODF= $(patsubst %,$(SRC_DIR)/%,$(MOD))
 INIF= $(patsubst %,$(SRC_DIR)/%,$(INI))

--- a/work/startfile
+++ b/work/startfile
@@ -26,6 +26,7 @@ If start==0, it will set the initial condition based on the choice of simtype.
 'iotest': Test the read/write routines
 ** Test files NOT available **
 'sedov_other': Sedov blast wave. Set model parameters in extras file.
+'eruption': 1D eruption of stars (Owocki+2019)
 'other_shocktube_{x,y,z}': User-specified shocktube problem in the x/y/z direction. Set model parameters in extras file.
 'rsg_sph': Do something with a red supergiant on spherical coordinates
 'agndisk': Explosions in AGN disks (Grishin+2021)


### PR DESCRIPTION
Some students are now working on HORMONE to reproduce results from Owocki+2019.

The code has evolved significantly since the publication, so a lot of work is needed to recreate the initial conditions to reproduce that work.
In the process, I have also added the following functionalities.

- `write_mc`: An option to output the mass coordinates for spherical coordinate simulations.
- `compswitch==1`: The spherical composition functionality was broken, but should now work.