### PR TITLE
Only apply divergence cleaning for multi-D

### DIFF
--- a/src/checksetup.f90
+++ b/src/checksetup.f90
@@ -49,7 +49,8 @@ subroutine checksetup
    call add_equation(img1,ufnmax) ! Magnetic field equation 1
    call add_equation(img2,ufnmax) ! Magnetic field equation 2
    call add_equation(img3,ufnmax) ! Magnetic field equation 3
-   call add_equation(i9wv,ufnmax) ! Divergence cleaning (9-wave method)
+   if(dim>1)&
+    call add_equation(i9wv,ufnmax) ! Divergence cleaning (9-wave method)
   end if
 
 ! Set uniform mesh if that dimension is not used

--- a/src/conserve.f90
+++ b/src/conserve.f90
@@ -13,7 +13,7 @@ contains
 subroutine conserve
 
   use settings,only:mag_on
-  use grid,only:is,ie,js,je,ks,ke
+  use grid,only:is,ie,js,je,ks,ke,dim
   use physval,only:u,d,e,v1,v2,v3,b1,b2,b3,phi,&
                    icnt,imo1,imo2,imo3,iene,img1,img2,img3,i9wv
 
@@ -35,6 +35,7 @@ subroutine conserve
      u(i,j,k,img1) = b1(i,j,k)
      u(i,j,k,img2) = b2(i,j,k)
      u(i,j,k,img3) = b3(i,j,k)
+     if(dim==1)cycle
      u(i,j,k,i9wv) = phi(i,j,k)
     end do
    end do

--- a/src/hormone.f90
+++ b/src/hormone.f90
@@ -143,7 +143,7 @@ program hormone
 
     call stop_clock(wthyd)
 
-    if(mag_on)           call phidamp
+    if(mag_on.and.dim>1) call phidamp
     if(radswitch>0)      call radiation
     if(include_cooling)  call cooling
     if(include_particles)call particles

--- a/src/numflux.f90
+++ b/src/numflux.f90
@@ -327,16 +327,16 @@ contains
 !!$      end if
 !!$     end if
 
-      flux2(i,j,k,1) = tmpflux(1)
-      flux2(i,j,k,2) = tmpflux(4)
-      flux2(i,j,k,3) = tmpflux(2)
-      flux2(i,j,k,4) = tmpflux(3)
-      flux2(i,j,k,5) = tmpflux(5)
+      flux2(i,j,k,icnt) = tmpflux(icnt)
+      flux2(i,j,k,imo1) = tmpflux(imo3)
+      flux2(i,j,k,imo2) = tmpflux(imo1)
+      flux2(i,j,k,imo3) = tmpflux(imo2)
+      flux2(i,j,k,iene) = tmpflux(iene)
       if(mag_on)then
-       flux2(i,j,k,6) = tmpflux(8)
-       flux2(i,j,k,7) = tmpflux(6)
-       flux2(i,j,k,8) = tmpflux(7)
-       flux2(i,j,k,9) = tmpflux(9)
+       flux2(i,j,k,img1) = tmpflux(img3)
+       flux2(i,j,k,img2) = tmpflux(img1)
+       flux2(i,j,k,img3) = tmpflux(img2)
+       if(dim>1)flux2(i,j,k,i9wv) = tmpflux(i9wv)
       end if
 
       if(compswitch>=2)then
@@ -488,16 +488,16 @@ contains
 !!$      end if
 !!$     end if
 
-      flux3(i,j,k,1) = tmpflux(1)
-      flux3(i,j,k,2) = tmpflux(3)
-      flux3(i,j,k,3) = tmpflux(4)
-      flux3(i,j,k,4) = tmpflux(2)
-      flux3(i,j,k,5) = tmpflux(5)
+      flux3(i,j,k,icnt) = tmpflux(icnt)
+      flux3(i,j,k,imo1) = tmpflux(imo2)
+      flux3(i,j,k,imo2) = tmpflux(imo3)
+      flux3(i,j,k,imo3) = tmpflux(imo1)
+      flux3(i,j,k,iene) = tmpflux(iene)
       if(mag_on)then
-       flux3(i,j,k,6) = tmpflux(7)
-       flux3(i,j,k,7) = tmpflux(8)
-       flux3(i,j,k,8) = tmpflux(6)
-       flux3(i,j,k,9) = tmpflux(9)
+       flux3(i,j,k,img1) = tmpflux(img2)
+       flux3(i,j,k,img2) = tmpflux(img3)
+       flux3(i,j,k,img3) = tmpflux(img1)
+       if(dim>1)flux3(i,j,k,i9wv) = tmpflux(i9wv)
       end if
 
       if(compswitch>=2)then

--- a/src/rungekutta.f90
+++ b/src/rungekutta.f90
@@ -7,7 +7,7 @@ contains
 
 !\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 !
-!                     　  SUBROUTINE RUNGEKUTTA
+!                         SUBROUTINE RUNGEKUTTA
 !
 !\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
@@ -217,6 +217,7 @@ end subroutine get_runge_coeff
      b1(i,j,k) = u(i,j,k,img1)
      b2(i,j,k) = u(i,j,k,img2)
      b3(i,j,k) = u(i,j,k,img3)
+     if(dim==1)cycle
      ! for 9 wave method
      phi(i,j,k)= u(i,j,k,i9wv)
     end do


### PR DESCRIPTION
The 9-wave method for magnetic field divergence cleaning should only be applied for multi-dimensional simulations. The damping in 1D could in fact be harmful.
Restrict the use of divergence cleaning to multi-D.