### PR TITLE
Reduce loss of precision

### DIFF
--- a/work/Makefile
+++ b/work/Makefile
@@ -14,7 +14,7 @@ FPPFLAG += -DMPI
 endif
 MODFLAG= -J
 FCFLAG:= $(CFLAG) -fopenmp -ffree-line-length-512 #-fmax-stack-var-size=32768
-DBFLAG= -ffpe-trap=invalid,zero,overflow -fbacktrace -O0 -Wall -Wextra -fcheck=all
+DBFLAG= -g -ffpe-trap=invalid,zero,overflow -fbacktrace -O0 -Wall -Wextra -fcheck=all
 PRFLAG= -pg -save-temps
 endif
 


### PR DESCRIPTION
The star setup involves operations that easily lose precision, which can lead to different numerical values on different machines. These small differences can grow into larger errors, which we found to be the case for the polytrope case.

Simply changing the order of operations in the star setup routine reduces the loss of precision significantly.

Other changes:
- Add `-g` to debug flags in Makefile
