### PR TITLE
Gravity bugfix

### DIFF
--- a/src/gravity.f90
+++ b/src/gravity.f90
@@ -183,14 +183,14 @@ subroutine gravity_relax
   call hyperbolic_gravity_step(cgrav,cgrav_old,dtgrav)
 
   ! Only calculate error every 1000 iterations because it is expensive
-  if (mod(i,1000)==0) then
+  if (mod(i,1000)==0 .or. i==1) then
    ! Error in Poisson equation, weighted by mass
    err = sum( ((lapphi(is:ie,js:je,ks:ke) - hgsrc(is:ie,js:je,ks:ke))/hgsrc(is:ie,js:je,ks:ke))**2 * mass )
    call allreduce_mpi('sum', err)
    err = sqrt(err)/sqrt(mtot)
    if (myrank==0) print*, 'iteration=', i, 'error=', err
    ! Converged if below tolerance
-   if (err < itertol) exit
+   if (err < itertol .and. i>0) exit
   endif
  enddo
 

--- a/src/gravity.f90
+++ b/src/gravity.f90
@@ -36,6 +36,8 @@ subroutine gravity
 ! Set source term for gravity
  call get_gsrc(gsrc)
 
+ if (tn==0) grvtime = 0.d0
+
  if(grav_init_relax .and. tn==0) then
   call gravity_relax
   call hg_boundary_conditions

--- a/src/gravity_hyperbolic.f90
+++ b/src/gravity_hyperbolic.f90
@@ -157,10 +157,13 @@ subroutine hg_boundary_conditions
  use settings
  use grid
  use gravmod
+ use mpi_domain,only:exchange_gravity_mpi
 
  integer:: i,j,k
 
 !-----------------------------------------------------------------------------
+
+ call exchange_gravity_mpi
 
  !$omp parallel
  select case(crdnt)

--- a/src/gravity_hyperbolic.f90
+++ b/src/gravity_hyperbolic.f90
@@ -221,6 +221,7 @@ subroutine hg_boundary_conditions
    !$omp do private(i,j) collapse(2)
    do j = js, je
     do i = is, ie
+     ! Note: in MPI mode, cell exchange already implements periodic BCs
      if(ks==ks_global .and. ke==ke_global) then
       grvphi(i,j,ks-1) = grvphi(i,j,ke)
       grvphi(i,j,ke+1) = grvphi(i,j,ks)

--- a/src/gravity_hyperbolic.f90
+++ b/src/gravity_hyperbolic.f90
@@ -73,12 +73,11 @@ subroutine hyperbolic_gravity_step(cgrav_now,cgrav_old,dtg)
 
 !-----------------------------------------------------------------------------
 
-! Perform MPI neighbour exchange
- call exchange_gravity_mpi
-
 !$omp parallel
  do grungen = 1, grktype
 !$omp single
+  ! Perform MPI neighbour exchange
+  call exchange_gravity_mpi
   call get_runge_coeff(grungen,grktype,faco,fact,facn)
 !$omp end single
 

--- a/src/gravity_hyperbolic.f90
+++ b/src/gravity_hyperbolic.f90
@@ -222,8 +222,10 @@ subroutine hg_boundary_conditions
    !$omp do private(i,j) collapse(2)
    do j = js, je
     do i = is, ie
-     if(ks==ks_global) grvphi(i,j,ks-1) = grvphi(i,j,ke)
-     if(ke==ke_global) grvphi(i,j,ke+1) = grvphi(i,j,ks)
+     if(ks==ks_global .and. ke==ke_global) then
+      grvphi(i,j,ks-1) = grvphi(i,j,ke)
+      grvphi(i,j,ke+1) = grvphi(i,j,ks)
+     end if
     end do
    end do
    !$omp end do


### PR DESCRIPTION
This PR fixes 3 bugs affecting gravity + MPI
- Gravity relaxation is run for at least 2 iterations rather than 1. `grvpsi` is only non-zero after the first iteration, so this allows for better fault-finding when trying to isolate a problem between the hydro and gravity solvers
- Gravity MPI exchange is performed before every RK step
- Periodic boundary conditions in the phi direction fixed for MPI with more than 1 task