### PR TITLE
Noninertialframe

### DIFF
--- a/para/parameters_base
+++ b/para/parameters_base
@@ -6,7 +6,7 @@
 	  is=1 ie=10 js=1 je=1 ks=1 ke=1
 	  imesh=0 jmesh=0 kmesh=0
 	  x1min=0d0 x2min=0 x3min=0d0
-	  fmr_max=0 fmr_lvl(1:20)=0/
+	  fmr_max=0 fmr_lvl(1:20)=0 /
 
 ! outstyle/endstyle : time=1, timestep=2
 ! tnlim : Upper limit for number of timesteps (only when outstyle=2)
@@ -46,11 +46,13 @@
 ! alpha9wave: ratio between diffusive and advection timescales (td/ta) of divB
 ! include_cooling: switch for cooling
 ! include_extforce: switch for external force provided in externalforce
+! frame: 0=inertial frame, >0=centre on sink(frame)
 ! extrasfile: file containing model parameters
 &simucon  crdnt=0 courant=0.9d0 rktype=3 mag_on=.false.
           flux_limiter='modified_mc' alpha9wave=0.1d0
           include_cooling = .false.
   	  include_extforce= .false.
+	  frame=0
           extrasfile='extras' /
 
 ! periodic:0, reflective:1, outgoing:2, free:3, linear:4, linear+outgoing:5,

--- a/src/checksetup.f90
+++ b/src/checksetup.f90
@@ -224,6 +224,12 @@ subroutine checksetup
 ! Output temperature if eostype>=1
   if(eostype>=1)write_temp = .true.
 
+! Enable external force if using noninertial frame
+  if(frame>0)then
+   include_extforce = .true.
+   include_sinks = .true.
+  end if
+
   return
  end subroutine checksetup
 

--- a/src/externalforce.f90
+++ b/src/externalforce.f90
@@ -15,11 +15,71 @@ subroutine externalforce
 
  use grid
  use physval
+ use utils,only:polcar,cylcar,get_vpol,get_vcyl
+ use sink_mod,only:sink
 
- implicit none
+ integer:: i,j,k
+ real(8),dimension(1:3):: atot,ftot,xcar
 
 !-----------------------------------------------------------------------------
 
+ select case(crdnt)
+ case(0) ! cartesian coordinates
+!$omp parallel do private(i,j,k,atot,ftot) collapse(3)
+  do k = ks, ke
+   do j = js, je
+    do i = is, ie
+     atot = frame_acc
+     ftot = d(i,j,k) * atot
+     src(i,j,k,imo1) = src(i,j,k,imo1) + ftot(1)
+     src(i,j,k,imo2) = src(i,j,k,imo2) + ftot(2)
+     src(i,j,k,imo3) = src(i,j,k,imo3) + ftot(3)
+     src(i,j,k,iene) = src(i,j,k,iene) &
+                     + (ftot(1)*v1(i,j,k)+ftot(2)*v2(i,j,k)+ftot(3)*v3(i,j,k)) &
+                     + 0.5d0*dot_product(ftot,atot)*dt
+    end do
+   end do
+  end do
+!$omp end parallel do
+
+ case(1) ! cylindrical coordinates
+!$omp parallel do private(i,j,k,xcar,atot,ftot) collapse(3)
+  do k = ks, ke
+   do j = js, je
+    do i = is, ie
+     xcar = cylcar([x1(i),x2(j),x3(k)])
+     call get_vcyl(xcar,x3(k),frame_acc,atot(1),atot(2),atot(3))
+     ftot = d(i,j,k) * atot
+     src(i,j,k,imo1) = src(i,j,k,imo1) + ftot(1)
+     src(i,j,k,imo2) = src(i,j,k,imo2) + ftot(2)
+     src(i,j,k,imo3) = src(i,j,k,imo3) + ftot(3)
+     src(i,j,k,iene) = src(i,j,k,iene) &
+                     + (ftot(1)*v1(i,j,k)+ftot(2)*v2(i,j,k)+ftot(3)*v3(i,j,k)) &
+                     + 0.5d0*dot_product(ftot,atot)*dt
+    end do
+   end do
+  end do
+!$omp end parallel do
+
+ case(2) ! spherical coordinates
+!$omp parallel do private(i,j,k,xcar,atot,ftot) collapse(3)
+  do k = ks, ke
+   do j = js, je
+    do i = is, ie
+     xcar = polcar([x1(i),x2(j),x3(k)])
+     call get_vpol(xcar,x3(k),frame_acc,atot(1),atot(2),atot(3))
+     ftot = d(i,j,k) * atot
+     src(i,j,k,imo1) = src(i,j,k,imo1) + ftot(1)
+     src(i,j,k,imo2) = src(i,j,k,imo2) + ftot(2)
+     src(i,j,k,imo3) = src(i,j,k,imo3) + ftot(3)
+     src(i,j,k,iene) = src(i,j,k,iene) &
+                     + (ftot(1)*v1(i,j,k)+ftot(2)*v2(i,j,k)+ftot(3)*v3(i,j,k)) &
+                     + 0.5d0*dot_product(ftot,atot)*dt
+    end do
+   end do
+  end do
+!$omp end parallel do
+ end select
 
 
  return

--- a/src/frame.f90
+++ b/src/frame.f90
@@ -1,0 +1,60 @@
+module frame_mod
+ implicit none
+
+contains
+
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+!
+!                       SUBROUTINE SET_FRAME_ACC
+!
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+! PURPOSE: To get the frame acceleration in case of noninertial frame
+
+ subroutine set_frame_acc
+
+  use settings,only:frame
+
+!-----------------------------------------------------------------------------
+
+  select case(frame)
+  case(0) ! inertial frame
+   return
+  case(1:) ! centre on sink
+   call centre_on_sink(frame)
+  case default
+   print*,'Error in value of frame; frame=',frame
+   stop
+  end select
+
+  return
+ end subroutine set_frame_acc
+
+
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+!
+!                      SUBROUTINE CENTRE_ON_SINK
+!
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+! PURPOSE: To set the frame to centre on a sink particle
+
+subroutine centre_on_sink(n)
+
+ use grid,only:frame_acc
+ use sink_mod,only:sink,get_sink_loc,get_sinkgas_acc,get_sinksink_acc
+
+ integer,intent(in):: n
+
+!-----------------------------------------------------------------------------
+
+ call get_sink_loc(sink(n))
+ call get_sinkgas_acc(sink(n))
+ call get_sinksink_acc(sink)
+
+ frame_acc = -sink(n)%a
+
+return
+end subroutine centre_on_sink
+
+end module frame_mod

--- a/src/gridset.f90
+++ b/src/gridset.f90
@@ -13,15 +13,17 @@ contains
 
 subroutine gridset
 
-  use settings,only:imesh,jmesh,kmesh,eq_sym,start,gravswitch,crdnt
-  use grid
-  use constants,only:pi
-  use utils,only:geometrical_series
-  use readbin_mod,only:readgrid
+ use settings,only:imesh,jmesh,kmesh,eq_sym,start,gravswitch,crdnt
+ use grid
+ use constants,only:pi
+ use utils,only:geometrical_series
+ use readbin_mod,only:readgrid
 
-  integer::i,j,k,jetmp,ketmp
+ integer::i,j,k,jetmp,ketmp
 
 !-------------------------------------------------------------------------
+
+ frame_acc = 0d0
 
  if(gravswitch/=0)then
   deallocate(x1, xi1, dx1, dxi1, idx1, idxi1, &

--- a/src/hormone.f90
+++ b/src/hormone.f90
@@ -47,6 +47,7 @@ program hormone
   use radiation_mod
   use particle_mod
   use cooling_mod
+  use frame_mod
   use dirichlet_mod
   use shockfind_mod
   use tests_mod
@@ -124,7 +125,8 @@ program hormone
     call timestep
 
     call gravity
-    if(include_sinks)call get_sink_acc(sink)
+    if(include_sinks)call get_sink_acc(sink) ! updates dt
+    call set_frame_acc
 
     call terminal_output
 

--- a/src/modules.f90
+++ b/src/modules.f90
@@ -15,7 +15,7 @@ module settings
  logical:: eq_sym, dirichlet_on, fluxbound_on
 ! numerical setups
  integer:: rktype, crdnt, tnlim, start, tn_out, tn_evo, outstyle, endstyle
- integer:: gravswitch, compswitch, radswitch
+ integer:: gravswitch, compswitch, radswitch, frame
  integer:: eostype, spn, sigfig, outres, gbtype, grktype, maxptc
  integer:: grvsrctype, opacitytype, lambdatype
  real(8):: courant, t_end, dt_out, dt_unit_in_sec, alpha9wave
@@ -68,6 +68,7 @@ module grid
   real(8),allocatable,dimension(:,:):: rdis, sincyl, coscyl
   real(8),allocatable,dimension(:,:,:,:):: car_x
   real(8),allocatable,dimension(:):: spinc_r,spinc_t
+  real(8):: frame_acc(1:3)
 
 end module grid
 

--- a/src/setup.f90
+++ b/src/setup.f90
@@ -172,7 +172,7 @@ subroutine read_parameters(filename)
                     write_evo, write_other_slice, write_temp, write_mc
  namelist /eos_con/ eostype, gamma, eoserr, compswitch, muconst, spn
  namelist /simucon/ crdnt, courant, rktype, mag_on, flux_limiter, alpha9wave,&
-                    include_cooling, include_extforce, extrasfile
+                    include_cooling, include_extforce, frame, extrasfile
  namelist /bouncon/ bc1is, bc1os, bc2is, bc2os, bc3is, bc3os, &
                     bc1iv, bc1ov, bc2iv, bc2ov, bc3iv, bc3ov, eq_sym
  namelist /gravcon/ gravswitch, grvsrctype, grverr, cgerr, HGfac, hgcfl, &

--- a/src/sinks.f90
+++ b/src/sinks.f90
@@ -11,8 +11,8 @@ module sink_mod
  type(sink_prop),allocatable,public:: sink(:)
  real(8),allocatable,public:: snkphi(:,:,:)
 
- public:: sink_motion,sinkfield,get_sink_acc
- private:: get_sink_loc,get_sinkgas_acc,get_sinksink_acc
+ public:: sink_motion,sinkfield,get_sink_acc,get_sink_loc,get_sinkgas_acc,&
+          get_sinksink_acc
 
 contains
 !\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
@@ -25,7 +25,7 @@ contains
 
 subroutine sink_motion
 
- use grid,only:dt
+ use grid,only:dt,frame_acc
  use profiler_mod
 
  integer:: n
@@ -34,9 +34,8 @@ subroutine sink_motion
 
  call start_clock(wtsnk)
 
- call get_sink_acc(sink)
-
  do n = 1, nsink
+  sink(n)%a = sink(n)%a + frame_acc
   sink(n)%v = sink(n)%v + sink(n)%a*dt
   sink(n)%x = sink(n)%x + sink(n)%v*dt
  end do
@@ -100,12 +99,15 @@ subroutine get_sink_acc(sink)
 
  use constants,only:huge
  use grid,only:dt
+ use profiler_mod
 
  type(sink_prop),allocatable,intent(inout):: sink(:)
  integer:: n
  real(8):: dtsink
 
 !-----------------------------------------------------------------------------
+
+ call start_clock(wtsnk)
 
  dtsink = huge
  do n = 1, nsink
@@ -117,6 +119,8 @@ subroutine get_sink_acc(sink)
  call get_sinksink_acc(sink)
 
  dt = min(dtsink,dt) ! update dt
+
+ call stop_clock(wtsnk)
 
  return
 end subroutine get_sink_acc

--- a/src/utils.f90
+++ b/src/utils.f90
@@ -32,6 +32,32 @@ contains
   xp(3) = atan2(x(2),x(1))
  end function carpol
 
+! convert cylindrical to cartesian coordinates
+ pure function cylcar(xp) result(x)
+  implicit none
+  real(8),intent(in):: xp(1:3)
+  real(8):: x(1:3)
+  real(16) :: xp2
+
+  ! Convert to quad precision
+  xp2 = real(xp(2),kind=16)
+
+  x(1) = xp(1)*real(cos(xp2),kind=8)
+  x(2) = xp(1)*real(sin(xp2),kind=8)
+  x(3) = xp(3)
+
+ end function cylcar
+
+! convert cartesian to cylindrical coordinates
+ pure function carcyl(x) result(xp)
+  implicit none
+  real(8),intent(in):: x(1:3)
+  real(8):: xp(1:3)
+  real(8),parameter:: tiny=1d-99
+  xp(1) = norm2(x(1:2))
+  xp(2) = atan2(x(2),x(1))
+  xp(3) = x(3)
+ end function carcyl
 
  pure function softened_pot(r,hsoft) result(phi)
 ! Softened potential from Price & Monaghan 2007 Appendix A
@@ -117,6 +143,33 @@ subroutine get_vpol(xcar,x3,vcar,v1,v2,v3)
 
 return
 end subroutine get_vpol
+
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+!                          SUBROUTINE GET_VCYL
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+! PURPOSE: To calculate Cylindrical vector components from Cartesian coordinates
+
+subroutine get_vcyl(xcar,x3,vcar,v1,v2,v3)
+
+ real(8),intent(in):: xcar(1:3),x3,vcar(1:3)
+ real(8),intent(out)::v1,v2,v3
+ real(8),dimension(1:3)::uvec1,uvec2,uvec3
+ real(8):: r
+
+!-----------------------------------------------------------------------------
+
+ r = norm2(xcar(1:2))
+ uvec1 = [ xcar(1)/r,xcar(2)/r,0d0]
+ uvec2 = [-xcar(2)/r,xcar(1)/r,0d0]
+ uvec3 = [0d0,0d0,1d0]
+
+ v1 = dot_product(vcar,uvec1)
+ v2 = dot_product(vcar,uvec2)
+ v3 = vcar(3)
+
+return
+end subroutine get_vcyl
 
 ! This function is equivalent to rotz(roty(rotz(uvec1,-x3),0.5*pi),x3)
 ! but expanded out, to reduce roundoff error


### PR DESCRIPTION
Add functionality to deal with noninertial frames.
For now, I want to enable the code to centre on a particular sink particle so that the grid can always be centred on a star. This would enable simulations to maintain high resolution in the stellar interior while also allowing it to model binary interactions, etc.

The way it work is that it first calculates the sink acceleration before the hydro step (this should have been written like this regardless of noninertial frames) and then applies the counter acceleration to all cells and sinks in the hydro and sink evolution steps.

TODOs for later:
- Add unit test for noninertial frame
- Make sink particles MPI-compatible 