### PR TITLE
Fix MPI bug in exchange spc

### DIFF
--- a/src/checksetup.f90
+++ b/src/checksetup.f90
@@ -19,6 +19,23 @@ subroutine checksetup
 
 !-----------------------------------------------------------------------------
 
+! Grid indices have to go from small to large
+  if(ie<is)then
+   print*,"Error in grid indices. Set indices so that ie>is"
+   print*,'is=',is,'ie=',ie
+   stop
+  end if
+  if(je<js)then
+   print*,"Error in grid indices. Set indices so that je>js"
+   print*,'js=',js,'je=',je
+   stop
+  end if
+  if(ke<ks)then
+   print*,"Error in grid indices. Set indices so that ke>ks"
+   print*,'ks=',ks,'ke=',ke
+   stop
+  end if
+
 ! Select which directions to solve
   solve_i=.false.;solve_j=.false.;solve_k=.false.
   if(ie>is)solve_i=.true.

--- a/src/interpolation.f90
+++ b/src/interpolation.f90
@@ -14,7 +14,7 @@ contains
 
 subroutine interpolation
 
- use settings,only:compswitch,spn,mag_on,flux_limiter, &
+ use settings,only:compswitch,spn,mag_on,flux_limiter,solve_i,solve_j,solve_k,&
                    bc1is,bc1os,bc2is,bc2os,bc3is,bc3os
 !  use settings, only:eostype
  use grid
@@ -48,7 +48,7 @@ subroutine interpolation
 !$omp parallel
 
 ! slope1 \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
-if(ie/=is)then
+if(solve_i)then
 !$omp do private(i,j,k,ptl,ptr,dl,dr,el,er,m1l,m1r,m2l,m2r,m3l,m3r,&
 !$omp b1l,b1r,b2l,b2r,b3l,b3r,phil,phir,uu,du,dx,eintl,eintr,imul,imur,n,x,xi,&
 !$omp Xl,Xr,Yl,Yr,Tini) collapse(3)
@@ -175,7 +175,7 @@ end if
 
 
 ! slope2 \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
-if(je/=js)then
+if(solve_j)then
 !$omp do private(i,j,k,ptl,ptr,dl,dr,el,er,m1l,m1r,m2l,m2r,m3l,m3r,&
 !$omp b1l,b1r,b2l,b2r,b3l,b3r,phil,phir,uu,du,dx,eintl,eintr,imul,imur,n,x,xi,&
 !$omp Xl,Xr,Yl,Yr,Tini) collapse(3)
@@ -300,7 +300,7 @@ end if
 
 
 ! slope3 \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
-if(ke/=ks)then
+if(solve_k)then
 !$omp do private(i,j,k,ptl,ptr,dl,dr,el,er,m1l,m1r,m2l,m2r,m3l,m3r,&
 !$omp b1l,b1r,b2l,b2r,b3l,b3r,phil,phir,uu,du,dx,eintl,eintr,imul,imur,n,x,xi,&
 !$omp Xl,Xr,Yl,Yr,Tini) collapse(3)

--- a/src/mpi_domain.F90
+++ b/src/mpi_domain.F90
@@ -241,7 +241,7 @@ module mpi_domain
          ! --- x-3 direction ---
          subsizes4 = [spn, ie-is+1, je-js+1, 2] ! Size of the ghost cells to send
          starts4   = [0, 2, 2, 0] ! Offset relative to the address passed to MPI_Sendrecv
-         call MPI_Type_create_subarray(3, sizes4, subsizes4, starts4, MPI_ORDER_FORTRAN, MPI_REAL8, subarray_spc(3), ierr)
+         call MPI_Type_create_subarray(4, sizes4, subsizes4, starts4, MPI_ORDER_FORTRAN, MPI_REAL8, subarray_spc(3), ierr)
          call MPI_Type_commit(subarray_spc(3), ierr)
 
          ! Starting indices of the real and ghost zones involved in the exchange

--- a/src/numflux.f90
+++ b/src/numflux.f90
@@ -27,11 +27,11 @@ contains
 
   real(8)::cfl, cfr, v1l, v1r, dl, dr, ptl, ptr, el, er, Tl, Tr, imul, imur, &
            b1l=0., b1r=0., b2l=0., b2r=0., b3l=0., b3r=0., phil=0., phir=0., &
-           v2l, v2r, v3l, v3r, eil, eir, csl, csr, fix
+           v2l, v2r, v3l, v3r, eil, eir, csl, csr
   real(8),dimension(1:9)::tmpflux
   real(8),dimension(1:2):: dx
   real(8),dimension(1:spn):: spcl,spcr
-  real(8):: signdflx,ul,ur,fl,fr,rinji
+  real(8):: signdflx,fix,ul,ur,fl,fr,rinji
   integer:: i,j,k,n,ierr
 
 !------------------------------------------------------------------------------
@@ -184,8 +184,8 @@ contains
         spcr(n) = spc(n,i+1,j,k) - dx(2) * dspc(n,i+1,j,k,1)
        end do
        signdflx = sign(0.5d0,flux1(i,j,k,icnt))
-       fix = 1d0/( sum(spcl(1:spn))*(0.5d0+signdflx) + &
-                   sum(spcr(1:spn))*(0.5d0-signdflx) )
+       fix = 1d0/( sum(spcl(1:spn))*(0.5d0+signdflx) &
+                 + sum(spcr(1:spn))*(0.5d0-signdflx) )
        do n = 1, spn
         spcflx(n,i,j,k,1) = fix * flux1(i,j,k,icnt) &
                  * ( spcl(n)*(0.5d0+signdflx) + spcr(n)*(0.5d0-signdflx) )
@@ -202,7 +202,8 @@ contains
   if(solve_j)then
 !$omp do private(i,j,k,ptl,ptr,dl,dr,el,er,v1l,v1r,v2l,v2r,v3l,v3r,eil,eir,&
 !$omp b1l,b1r,b2l,b2r,b3l,b3r,cfl,cfr,phil,phir,tmpflux,dx,Tl,Tr,&
-!$omp imul,imur,csl,csr,fix,spcl,spcr,signdflx,n,ierr) collapse(3)
+!$omp imul,imur,csl,csr,fix,spcl,spcr,signdflx,n,ul,ur,fl,fr,rinji,ierr) &
+!$omp collapse(3)
    do k = ks,ke
     do j = js-1,je
      do i = is,ie
@@ -345,8 +346,8 @@ contains
         spcr(n) = spc(n,i,j+1,k) - dx(2) * dspc(n,i,j+1,k,2)
        end do
        signdflx = sign(0.5d0,flux2(i,j,k,icnt))
-       fix = 1d0/( sum(spcl(1:spn))*(0.5d0+signdflx) + &
-                   sum(spcr(1:spn))*(0.5d0-signdflx) )
+       fix = 1d0/( sum(spcl(1:spn))*(0.5d0+signdflx) &
+                 + sum(spcr(1:spn))*(0.5d0-signdflx) )
        do n = 1, spn
         spcflx(n,i,j,k,2) = fix * flux2(i,j,k,icnt) &
                * ( spcl(n)*(0.5d0+signdflx) + spcr(n)*(0.5d0-signdflx) )
@@ -506,8 +507,8 @@ contains
         spcr(n) = spc(n,i,j,k+1) - dx(2) * dspc(n,i,j,k+1,3)
        end do
        signdflx = sign(0.5d0,flux3(i,j,k,icnt))
-       fix = 1d0/( sum(spcl(1:spn))*(0.5d0+signdflx) + &
-                   sum(spcr(1:spn))*(0.5d0-signdflx) )
+       fix = 1d0/( sum(spcl(1:spn))*(0.5d0+signdflx) &
+                 + sum(spcr(1:spn))*(0.5d0-signdflx) )
        do n = 1, spn
         spcflx(n,i,j,k,3) = fix * flux3(i,j,k,icnt) &
                * ( spcl(n)*(0.5d0+signdflx) + spcr(n)*(0.5d0-signdflx) )

--- a/src/output.f90
+++ b/src/output.f90
@@ -5,7 +5,7 @@ module output_mod
  public:: output,terminal_output,set_file_name,write_extgrv,evo_output,&
           scaling_output, write_grid
  private:: write_bin,write_plt,get_header,add_column, &
-           write_val
+           write_val,write_vertical_slice
 
  contains
 

--- a/src/profiler.f90
+++ b/src/profiler.f90
@@ -80,9 +80,9 @@ subroutine init_profiler
 
 ! Make sure to keep routine name short
  routine_name(wtini) = 'Setup'       ! initial conditions
- routine_name(wtgri) = '1st_Gravity' ! initial gravity
- routine_name(wtou1) = '1st_Output'  ! initial output
- routine_name(wtlop) = 'Main_loop'   ! main loop
+ routine_name(wtgri) = '1st Gravity' ! initial gravity
+ routine_name(wtou1) = '1st Output'  ! initial output
+ routine_name(wtlop) = 'Main loop'   ! main loop
  routine_name(wthyd) = 'Hydro'       ! hydrodynamics
  routine_name(wtflx) = 'Numflux'     ! numerical flux
  routine_name(wtrng) = 'RungeKutta'  ! Runge-Kutta
@@ -99,7 +99,7 @@ subroutine init_profiler
  routine_name(wtsho) = 'Shockfind'   ! shockfind
  routine_name(wtrad) = 'Radiation'   ! radiation
  routine_name(wtopc) = 'Opacity'     ! opacity
- routine_name(wtrfl) = 'Rad_flux'    ! radiative flux
+ routine_name(wtrfl) = 'Rad flux'    ! radiative flux
  routine_name(wtsnk) = 'Sinks'       ! sink particles
  routine_name(wtmpi) = 'MPI exchange'! MPI exchange
  routine_name(wtwai) = 'MPI wait'    ! MPI wait

--- a/src/sn2022jli.f90
+++ b/src/sn2022jli.f90
@@ -166,7 +166,7 @@ subroutine sn2022jli
   phinow(1) = newphi
   gradphi = dx1(i+1)**2*phinow(3)-dx1(i+2)**2*phinow(1)+(dx1(i+2)**2-dx1(i+1)**2)*phinow(2)
   p1d(i) = (dnow*gradphi+dx1(i+1)**2*p1d(i+2)+(dx1(i+2)**2-dx1(i+1)**2)*p1d(i+1))/dx1(i+2)**2
-  p(i,js:je,ks:ke) = p1d(i)
+  if(i>=is.and.i<=ie)p(i,js:je,ks:ke) = p1d(i)
  end do
 
 ! Remember core mass


### PR DESCRIPTION
There was a typo in the `setup_mpi_exchange` routine for the size of the ghost cell array for `spc`.
Fixed this bug along with some other cosmetic changes to the code.