### PR TITLE
Bug fixes and profiler for smearing

### DIFF
--- a/src/mpi_utils.F90
+++ b/src/mpi_utils.F90
@@ -77,7 +77,7 @@ module mpi_utils
     real(8), allocatable :: value_reduced(:)
     integer :: op, ierr
 
-    allocate(value_reduced(size(value)))
+    allocate(value_reduced,mold=value)
 
     select case (op_str)
     case ('sum')

--- a/src/output.f90
+++ b/src/output.f90
@@ -945,8 +945,10 @@ subroutine write_vertical_slice(slice,prefix)
  call open_file_write_ascii(verfile,ui)
 
 ! Write time and time step
- write(ui,'(a,i7,a,1PE12.4e2,a)')&
-   '#tn =',tn,'  time= ',time/dt_unit_in_sec,dt_unit
+ write(str,'(a,i7,a,1PE12.4e2,a)')&
+      '#tn =',tn,'  time= ',time/dt_unit_in_sec,dt_unit
+ call write_string_master(ui,str)
+
 ! Decide what quantities to write
  call get_header(header,columns)
  do n = 1, columns

--- a/src/profiler.f90
+++ b/src/profiler.f90
@@ -2,7 +2,7 @@ module profiler_mod
  implicit none
 
  public:: init_profiler,profiler_output1,start_clock,stop_clock,reset_clock
- integer,parameter:: n_wt=24 ! number of profiling categories
+ integer,parameter:: n_wt=25 ! number of profiling categories
  real(8):: wtime(0:n_wt),wtime_max(0:n_wt),wtime_min(0:n_wt),wtime_avg(0:n_wt),imbalance(0:n_wt)
  integer,parameter:: &
   wtini=1 ,& ! initial conditions
@@ -16,19 +16,20 @@ module profiler_mod
   wtsrc=9 ,& ! source terms
   wtint=10,& ! MUSCL interpolation
   wteos=11,& ! equation of state
-  wttim=12,& ! time stepping
-  wtgrv=13,& ! gravity
-  wtgbn=14,& ! gravbound
-  wtpoi=15,& ! Poisson solver
-  wthyp=16,& ! hyperbolic self-gravity
-  wtsho=17,& ! shockfind
-  wtrad=18,& ! radiation
-  wtopc=19,& ! opacity
-  wtrfl=20,& ! radiative flux
-  wtsnk=21,& ! sink particles
-  wtout=22,& ! output
-  wtmpi=23,& ! mpi exchange
-  wtwai=24,& ! mpi wait
+  wtsmr=12,& ! smearing
+  wttim=13,& ! time stepping
+  wtgrv=14,& ! gravity
+  wtgbn=15,& ! gravbound
+  wtpoi=16,& ! Poisson solver
+  wthyp=17,& ! hyperbolic self-gravity
+  wtsho=18,& ! shockfind
+  wtrad=19,& ! radiation
+  wtopc=20,& ! opacity
+  wtrfl=21,& ! radiative flux
+  wtsnk=22,& ! sink particles
+  wtout=23,& ! output
+  wtmpi=24,& ! mpi exchange
+  wtwai=25,& ! mpi wait
   wttot=0    ! total
  integer,public:: parent(0:n_wt),maxlbl
  character(len=30),public:: routine_name(0:n_wt)
@@ -63,6 +64,7 @@ subroutine init_profiler
  parent(wtsrc) = wthyd ! source terms
  parent(wtint) = wthyd ! MUSCL interpolation
  parent(wteos) = wthyd ! equation of state
+ parent(wtsmr) = wthyd ! smearing
  parent(wttim) = wtlop ! time stepping
  parent(wtgrv) = wtlop ! gravity
  parent(wtgbn) = wtgrv ! gravbound
@@ -90,6 +92,7 @@ subroutine init_profiler
  routine_name(wtsrc) = 'Source'      ! source terms
  routine_name(wtint) = 'Interpolate' ! MUSCL interpolation
  routine_name(wteos) = 'EoS'         ! equation of state
+ routine_name(wtsmr) = 'Smearing'    ! smearing
  routine_name(wttim) = 'Timestep'    ! time stepping
  routine_name(wtgrv) = 'Gravity'     ! gravity
  routine_name(wtgbn) = 'Gravbound'   ! gravbound

--- a/src/rungekutta.f90
+++ b/src/rungekutta.f90
@@ -88,11 +88,9 @@ contains
 
   call stop_clock(wtrng)
 
-
-  call start_clock(wteos)
-
   call smear
 
+  call start_clock(wteos)
   call primitive
   call stop_clock(wteos)
 

--- a/src/star.f90
+++ b/src/star.f90
@@ -91,7 +91,6 @@ subroutine set_star_sph_grid(r,m,rho,pres,comp,comp_list)
  use physval
  use gravmod,only:grvphi,mc
  use utils,only:intpol
- use mpi_utils,only:allreduce_mpi
  use mpi_domain,only:sum_global_array
 
  real(8),allocatable,dimension(:),intent(in):: r,m,rho,pres

--- a/src/utils.f90
+++ b/src/utils.f90
@@ -63,7 +63,7 @@ contains
   implicit none
   real(8),intent(in):: r,hsoft
   real(8):: phi,h,q
-  h = 0.5d0*max(hsoft,1d-99)
+  h = 0.5d0*max(hsoft,r*0.5d0,1d-99)
   q=r/h
   if(q>=2d0)then
    phi = -1d0/r
@@ -80,7 +80,7 @@ contains
   implicit none
   real(8),intent(in):: r,hsoft
   real(8)::acc,h,q
-  h = 0.5d0*max(hsoft,1d-99)
+  h = 0.5d0*max(hsoft,r*0.5d0,1d-99)
   q = r/h
   if(q<1d0)then
    acc=(4d0/3d0*q-1.2d0*q**3+0.5d0*q**4)/h**2


### PR DESCRIPTION
Fixed the following small bugs
- `write_vertical_slice` was outputted in the wrong unit number.
- smearing for `spc` was MPI unsafe.
- `softened_pot` and `softened_acc` could crash when `r=hsoft=0d0`.