### PR TITLE
Optimize smearing

### DIFF
--- a/src/allocations.f90
+++ b/src/allocations.f90
@@ -47,7 +47,7 @@ subroutine allocations
 
  allocate(dvol(is_global-2:ie_global+2,js_global-2:je_global+2,ks_global-2:ke_global+2))
  allocate(idetg3,sa1,sa2,sa3,Imom,mold=dvol)
- allocate(car_x(1:3,is:ie,js:je,ks:ke))
+ allocate(car_x(1:3,is-1:ie+1,js-1:je+1,ks-1:ke+1))
 
 ! 3 dimensional arrays =======================================================
 ! physical variables

--- a/src/gravity_hyperbolic.f90
+++ b/src/gravity_hyperbolic.f90
@@ -118,7 +118,7 @@ subroutine hyperbolic_gravity_step(cgrav_now,cgrav_old,dtg)
        il = max(i,is); ir = min(i,ie)
        jl = max(j,js); jr = min(j+jb,je)
        kl = max(k,ks); kr = min(k+kb,ke)
-       vol = sum_global_array(dvol,i,i,j,j+jb,k,k+kb)
+       vol = sum(dvol(i,j:j+jb,k:k+kb))
 
        grvphi(il:ir,jl:jr,kl:kr) = &
                   sum_global_array(grvphi,i,i,j,j+jb,k,k+kb, weight=dvol) / vol

--- a/src/metric.f90
+++ b/src/metric.f90
@@ -129,9 +129,9 @@ subroutine metric
    end do
   end do
 
-  do k = ks, ke
-   do j = js, je
-    do i = is, ie
+  do k = ks-1, ke+1
+   do j = js-1, je+1
+    do i = is-1, ie+1
      car_x(1:3,i,j,k) = polcar([x1(i),x2(j),x3(k)])
     end do
    end do

--- a/src/mpi_domain.F90
+++ b/src/mpi_domain.F90
@@ -1,4 +1,3 @@
-
 module mpi_domain
 #ifdef MPI
    use mpi
@@ -634,6 +633,21 @@ module mpi_domain
           is_my_domain(i+ib-1,j+jb-1,k+kb-1)
 
    end function partially_my_domain
+
+   logical function fully_my_domain(i,j,k,ib,jb,kb)
+      integer, intent(in) :: i, j, k, ib, jb, kb
+
+      fully_my_domain = &
+          is_my_domain(i     ,j     ,k     ).and.&
+          is_my_domain(i     ,j+jb-1,k     ).and.&
+          is_my_domain(i     ,j     ,k+kb-1).and.&
+          is_my_domain(i     ,j+jb-1,k+kb-1).and.&
+          is_my_domain(i+ib-1,j     ,k     ).and.&
+          is_my_domain(i+ib-1,j+jb-1,k     ).and.&
+          is_my_domain(i+ib-1,j     ,k+kb-1).and.&
+          is_my_domain(i+ib-1,j+jb-1,k+kb-1)
+
+   end function fully_my_domain
 
    function sum_global_array_scalar(array, is_, ie_, js_, je_, ks_, ke_, weight) result(arr_sum)
       use mpi_utils, only: allreduce_mpi

--- a/src/output.f90
+++ b/src/output.f90
@@ -19,7 +19,7 @@ module output_mod
 
 subroutine output
 
- use settings,only:is_test,in_loop
+ use settings,only:is_test
  use grid,only:tn
  use profiler_mod
  use mpi_utils,only:barrier_mpi
@@ -30,7 +30,7 @@ subroutine output
 
  if(is_test) return ! do not bother outputting anything if it is a test
 
- if(.not.in_loop)then
+ if(tn==0)then
   wtind = wtou1 ! Record time of initial output separately
  else
   wtind = wtout

--- a/src/smear.f90
+++ b/src/smear.f90
@@ -74,23 +74,25 @@ subroutine smear
   call allreduce_mpi('sum',smeared)
 
 ! Second sweep (for effective cells that span over multiple MPI ranks)
-  do n = 1, fmr_max
-   if(fmr_lvl(n)==0)cycle
-   if(n==1)then
-    jb=je_global-js_global+1; kb=ke_global-ks_global+1
-   else
-    jb=min(2**(fmr_max-n+1),je_global) ; kb=min(2**(fmr_max-n+1),ke_global)
-   end if
-   do k = ks_global, ke_global, kb
-    do j = js_global, je_global, jb
-     do i = is_global+sum(fmr_lvl(0:n-1)), is_global+sum(fmr_lvl(0:n))-1
-      if(smeared(get_id(i,j,k))==0)then
-       call angular_smear_global(i,j,j+jb-1,k,k+kb-1)
-      end if
+  if(minval(smeared)==0)then
+   do n = 1, fmr_max
+    if(fmr_lvl(n)==0)cycle
+    if(n==1)then
+     jb=je_global-js_global+1; kb=ke_global-ks_global+1
+    else
+     jb=min(2**(fmr_max-n+1),je_global) ; kb=min(2**(fmr_max-n+1),ke_global)
+    end if
+    do k = ks_global, ke_global, kb
+     do j = js_global, je_global, jb
+      do i = is_global+sum(fmr_lvl(0:n-1)), is_global+sum(fmr_lvl(0:n))-1
+       if(smeared(get_id(i,j,k))==0)then
+        call angular_smear_global(i,j,j+jb-1,k,k+kb-1)
+       end if
+      end do
      end do
     end do
    end do
-  end do
+  end if
 
  end if
 
@@ -102,7 +104,7 @@ end subroutine smear
 ! Get smeared cell id from i,j,k \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 function get_id(i,j,k) result(id)
 
- use grid,only:is_global,ie_global,js_global,je_global,ks_global,ke_global,&
+ use grid,only:is_global,js_global,je_global,ks_global,ke_global,&
                fmr_max,fmr_lvl
 
  integer,intent(in):: i,j,k
@@ -144,7 +146,7 @@ end function get_id
  subroutine angular_smear(i,js_,je_,ks_,ke_)
 
   use settings,only:spn,compswitch
-  use grid,only:x3,dvol,js,je,ks,ke,car_x
+  use grid,only:x3,dvol,car_x
   use physval,only:u,spc,v1,v2,v3,icnt,iene,imo1,imo2,imo3
   use utils
   use gravmod,only:totphi,gravswitch

--- a/src/smear.f90
+++ b/src/smear.f90
@@ -1,6 +1,7 @@
 module smear_mod
  implicit none
 
+ integer:: nsmear
 contains
 
 !\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
@@ -18,10 +19,13 @@ subroutine smear
  use physval
  use composition_mod
  use profiler_mod
+ use mpi_domain,only:fully_my_domain
+ use mpi_utils,only:allreduce_mpi
 
  implicit none
 
  integer:: i,j,k,n,jb,kb
+ integer,allocatable:: smeared(:)
 
 !-----------------------------------------------------------------------------
 
@@ -34,17 +38,55 @@ subroutine smear
 
  if(crdnt==2)then
 
+! Count number of smeared effective cells
+  nsmear = fmr_lvl(1)
+  do n = 2, fmr_max
+   nsmear = nsmear + fmr_lvl(n) &
+                     * max(1,(je_global-js_global+1)/2**(fmr_max-n+1)) &
+                     * max(1,(ke_global-ks_global+1)/2**(fmr_max-n+1))
+  end do
+
+  allocate( smeared(1:nsmear) )
+  smeared = 0
+
+! First sweep
   do n = 1, fmr_max
    if(fmr_lvl(n)==0)cycle
    if(n==1)then
-    jb=je_global-js_global; kb=ke_global-ks_global
+    jb=je_global-js_global+1; kb=ke_global-ks_global+1
    else
-    jb=min(2**(fmr_max-n+1),je_global)-1 ; kb=min(2**(fmr_max-n+1),ke_global)-1
+    jb=min(2**(fmr_max-n+1),je_global) ; kb=min(2**(fmr_max-n+1),ke_global)
    end if
-   do k = ks_global, ke_global, kb+1
-    do j = js_global, je_global, jb+1
+!$omp parallel do private(i,j,k) collapse(3)
+   do k = ks_global, ke_global, kb
+    do j = js_global, je_global, jb
      do i = is_global+sum(fmr_lvl(0:n-1)), is_global+sum(fmr_lvl(0:n))-1
-      call angular_smear(i,j,j+jb,k,k+kb)
+      if(fully_my_domain(i,j,k,0,jb,kb))then
+       call angular_smear(i,j,j+jb-1,k,k+kb-1)
+       smeared(get_id(i,j,k)) = 1
+      end if
+     end do
+    end do
+   end do
+!$omp end parallel do
+  end do
+
+  call allreduce_mpi('sum',smeared)
+
+! Second sweep (for effective cells that span over multiple MPI ranks)
+  do n = 1, fmr_max
+   if(fmr_lvl(n)==0)cycle
+   if(n==1)then
+    jb=je_global-js_global+1; kb=ke_global-ks_global+1
+   else
+    jb=min(2**(fmr_max-n+1),je_global) ; kb=min(2**(fmr_max-n+1),ke_global)
+   end if
+   do k = ks_global, ke_global, kb
+    do j = js_global, je_global, jb
+     do i = is_global+sum(fmr_lvl(0:n-1)), is_global+sum(fmr_lvl(0:n))-1
+      if(smeared(get_id(i,j,k))==0)then
+       call angular_smear_global(i,j,j+jb-1,k,k+kb-1)
+      end if
      end do
     end do
    end do
@@ -57,6 +99,39 @@ subroutine smear
  return
 end subroutine smear
 
+! Get smeared cell id from i,j,k \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+function get_id(i,j,k) result(id)
+
+ use grid,only:is_global,ie_global,js_global,je_global,ks_global,ke_global,&
+               fmr_max,fmr_lvl
+
+ integer,intent(in):: i,j,k
+ integer:: n, id, jn,kn
+
+ do n = 1, fmr_max
+  if(i<=is_global+sum(fmr_lvl(0:n))-1)exit
+
+  if(n==1)then
+   id = fmr_lvl(1)
+  else
+   jn = max(1,(je_global-js_global+1)/2**(fmr_max-n+1))
+   kn = max(1,(ke_global-ks_global+1)/2**(fmr_max-n+1))
+   id = id + fmr_lvl(n)*jn*kn
+  end if
+ end do
+ if(n>fmr_max)error stop 1
+
+ if(n==1)then
+  id = i
+ else
+  jn = max(1,(je_global-js_global+1)/2**(fmr_max-n+1))
+  kn = max(1,(ke_global-ks_global+1)/2**(fmr_max-n+1))
+  id = id + (i-sum(fmr_lvl(0:n-1))-1) * jn * kn &
+          + (j/2**(fmr_max-n+1)) + (k/2**(fmr_max-n+1))*jn + 1
+ end if
+
+return
+end function get_id
 
 !\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 !
@@ -73,6 +148,83 @@ end subroutine smear
   use physval,only:u,spc,v1,v2,v3,icnt,iene,imo1,imo2,imo3
   use utils
   use gravmod,only:totphi,gravswitch
+
+  implicit none
+
+  integer,intent(in)::i,js_,je_,ks_,ke_
+  integer:: n,j,k
+  real(8):: mtot, etot, spctot, vol, dave
+  real(8),dimension(1:3):: momtot, compen, tempsum, element, vcar, vave
+
+!-----------------------------------------------------------------------------
+
+  vol = sum(dvol(i,js_:je_,ks_:ke_))
+  mtot = sum(u(i,js_:je_,ks_:ke_,icnt)*dvol(i,js_:je_,ks_:ke_))
+
+  if(compswitch>=2)then
+   do n = 1, spn
+    spctot = sum(spc(n,i,js_:je_,ks_:ke_)*u(i,js_:je_,ks_:ke_,icnt)&
+                                         *dvol(i,js_:je_,ks_:ke_))
+    spc(n,i,js_:je_,ks_:ke_) = spctot / mtot
+   end do
+  end if
+
+  momtot=0d0;etot=0d0;compen=0d0
+  do k = ks_, ke_
+   do j = js_, je_
+    call get_vcar(car_x(:,i,j,k),x3(k),&
+                  u(i,j,k,imo1),u(i,j,k,imo2),u(i,j,k,imo3),vcar)
+! Use Kahan summation algorithm to minimize roundoff error
+    element = vcar*dvol(i,j,k)-compen
+    tempsum = momtot + element
+    compen = get_compensation(element,tempsum,momtot)
+    momtot = tempsum ! add up momenta using the Kahan algorithm
+!!$     u(i,j,k,imo1) = vcar(1)
+!!$     u(i,j,k,imo2) = vcar(2)
+!!$     u(i,j,k,imo3) = vcar(3)
+!!$     momtot = momtot + vcar*dvol(i,j,k)
+    etot = etot + u(i,j,k,iene)*dvol(i,j,k)! add up energy
+    if(gravswitch>0)& ! and gravitational energy
+     etot = etot + u(i,j,k,icnt)*totphi(i,j,k)*dvol(i,j,k)
+   end do
+  end do
+
+  dave = mtot/vol    ! get average density
+  vave = momtot/mtot ! get average cartesian velocity
+
+  do k = ks_, ke_
+   do j = js_, je_
+    u(i,j,k,icnt) = dave ! density
+    call get_vpol(car_x(:,i,j,k),x3(k),vave,&
+                  v1(i,j,k),v2(i,j,k),v3(i,j,k))
+    u(i,j,k,imo1) = v1(i,j,k)*dave
+    u(i,j,k,imo2) = v2(i,j,k)*dave
+    u(i,j,k,imo3) = v3(i,j,k)*dave
+    if(gravswitch>0)&
+     etot = etot - u(i,j,k,icnt)*totphi(i,j,k)*dvol(i,j,k)
+   end do
+  end do
+
+  u(i,js_:je_,ks_:ke_,iene) = etot / vol
+
+ end subroutine angular_smear
+
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+!
+!                     SUBROUTINE ANGULAR_SMEAR_GLOBAL
+!
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+! PURPOSE: Average out quantities over several cells in the angular direction
+!          Particularly for smearing over multiple MPI ranks
+
+ subroutine angular_smear_global(i,js_,je_,ks_,ke_)
+
+  use settings,only:spn,compswitch
+  use grid,only:x3,dvol,js,je,ks,ke,car_x
+  use physval,only:u,spc,v1,v2,v3,icnt,iene,imo1,imo2,imo3
+  use utils
+  use gravmod,only:totphi,gravswitch
   use mpi_utils,only:allreduce_mpi
   use mpi_domain,only:sum_global_array,partially_my_domain
 
@@ -80,7 +232,7 @@ end subroutine smear
 
   integer,intent(in)::i,js_,je_,ks_,ke_
   integer:: n,j,k,jl,jr,kl,kr
-  real(8):: mtot, etot, spctot, vol
+  real(8):: mtot, etot, spctot, vol, dave
   real(8),dimension(1:3):: momtot, compen, tempsum, element, vcar, vave
   logical:: overlap
 
@@ -120,25 +272,28 @@ end subroutine smear
    end do
   end if
 
+  dave = mtot/vol
   call allreduce_mpi('sum',momtot)
   vave = momtot/mtot ! get average cartesian velocity
-
-  if (overlap) u(i,jl:jr,kl:kr,icnt) = mtot/vol ! density
 
   if (overlap) then
    do k = kl, kr
     do j = jl, jr
-     call get_vpol(car_x(:,i,j,k),x3(k),vave,v1(i,j,k),v2(i,j,k),v3(i,j,k))
-     u(i,j,k,2) = v1(i,j,k)*u(i,j,k,icnt)
-     u(i,j,k,3) = v2(i,j,k)*u(i,j,k,icnt)
-     u(i,j,k,4) = v3(i,j,k)*u(i,j,k,icnt)
+     u(i,j,k,icnt) = dave ! density
+     call get_vpol(car_x(:,i,j,k),x3(k),vave,&
+                   v1(i,j,k),v2(i,j,k),v3(i,j,k))
+     u(i,j,k,imo1) = v1(i,j,k)*dave
+     u(i,j,k,imo2) = v2(i,j,k)*dave
+     u(i,j,k,imo3) = v3(i,j,k)*dave
      if(gravswitch>0)&
       etot = etot - u(i,j,k,icnt)*totphi(i,j,k)*dvol(i,j,k)
     end do
    end do
-  endif
+  end if
+
   call allreduce_mpi('sum',etot)
   if (overlap) u(i,jl:jr,kl:kr,iene) = etot / vol
+
 
 !!$  Jtot = 0d0; Itot=0d0; momtot=0d0; vol = sum(dvol(i,js:je,ks:ke))
 !!$  do k = ks, ke
@@ -204,7 +359,7 @@ end subroutine smear
 !!$  end do
 
  return
-end subroutine angular_smear
+end subroutine angular_smear_global
 
 pure elemental function get_compensation(y,t,s) result(c)
 ! Get compensation term for the Kahan-Babuska-Neumaier method

--- a/src/sn2022jli.f90
+++ b/src/sn2022jli.f90
@@ -158,7 +158,7 @@ subroutine sn2022jli
  do i = ie_global-1, is_global, -1
   phinow(2:3) = phinow(1:2)
   dnow = 0d0 ; newphi = 0d0
-  if(i  >=is.and.i  <=ie)newphi = grvphi(i,js,ks)
+  if(i  >=is.and.i  <=ie)newphi = totphi(i,js,ks)
   if(i+1>=is.and.i+1<=ie)dnow   = d(i+1,js,ks)
 
   call allreduce_mpi('max',dnow)


### PR DESCRIPTION
Smearing is a severe bottleneck for the simulation for MPI runs.
This is because there is a lot of global summations going on and therefore the whole subroutine is a serial run without even OpenMP parallelization.

This can be improved by doing two sweeps of smearing.
In the first sweep, all effective cells that are fully contained within an MPI rank can be smeared in the classical way with OpenMP parallelization. At this point, we record the cells that have been smeared already.

In the second sweep, we smear the cells that were not smeared previously. These effective cells should all span over multiple MPI ranks so should be done in serial with global reduction.

With this method, the only MPI communication that happens is for the cells that span over multiple MPI ranks. In practice, most cells are fully contained within their own MPI domains except for the central cells so there should be hardly any communication.

This greatly improves the scaling of the code when smearing is switched on.