### PR TITLE
Optimize gravity smearing

### DIFF
--- a/src/gravity_hyperbolic.f90
+++ b/src/gravity_hyperbolic.f90
@@ -68,9 +68,8 @@ subroutine hyperbolic_gravity_step(cgrav_now,cgrav_old,dtg)
  use mpi_domain,only:exchange_gravity_mpi,sum_global_array
 
  real(8),intent(in):: dtg,cgrav_now,cgrav_old
- integer:: i,j,k,n,jb,kb,grungen
- integer:: il,ir,jl,jr,kl,kr
- real(8):: faco, facn, fact, vol
+ integer:: i,j,k,grungen
+ real(8):: faco, facn, fact
 
 !-----------------------------------------------------------------------------
 

--- a/src/gravity_hyperbolic.f90
+++ b/src/gravity_hyperbolic.f90
@@ -64,6 +64,7 @@ subroutine hyperbolic_gravity_step(cgrav_now,cgrav_old,dtg)
  use grid
  use gravmod,only:grvphiorg,grvphi,grvpsi,lapphi,hgsrc,gsrc,hgcfl
  use rungekutta_mod,only:get_runge_coeff
+ use smear_mod,only:smear
  use mpi_domain,only:exchange_gravity_mpi,sum_global_array
 
  real(8),intent(in):: dtg,cgrav_now,cgrav_old
@@ -73,13 +74,14 @@ subroutine hyperbolic_gravity_step(cgrav_now,cgrav_old,dtg)
 
 !-----------------------------------------------------------------------------
 
-!$omp parallel
+
  do grungen = 1, grktype
-!$omp single
-  ! Perform MPI neighbour exchange
+
+! Perform MPI neighbour exchange
   call exchange_gravity_mpi
   call get_runge_coeff(grungen,grktype,faco,fact,facn)
-!$omp end single
+
+!$omp parallel
 
 ! First set flux and source term
   call get_lapphi_hgsrc(grvphi,gsrc,lapphi,hgsrc)
@@ -100,43 +102,18 @@ subroutine hyperbolic_gravity_step(cgrav_now,cgrav_old,dtg)
    end do
   end do
 !$omp end do
+!$omp end parallel
 
 ! Smear gravity in central regions --------------------------------------------
-!$omp single
-  if(fmr_max>0)then
-   do n = 1, fmr_max
-    if(fmr_lvl(n)==0)cycle
-    jb=min(2**(fmr_max-n+1),je_global)-1 ; kb=min(2**(fmr_max-n+1),ke_global)-1
-    if(n==1)then
-     jb=je_global-js_global; kb=ke_global-ks_global
-    end if
-    do k = ks_global, ke_global, kb+1
-     do j = js_global, je_global, jb+1
-      do i = is_global+sum(fmr_lvl(0:n-1)), is_global+sum(fmr_lvl(0:n))-1
-! When il>ir, no cells are selected, so no operation is performed
 
-       il = max(i,is); ir = min(i,ie)
-       jl = max(j,js); jr = min(j+jb,je)
-       kl = max(k,ks); kr = min(k+kb,ke)
-       vol = sum(dvol(i,j:j+jb,k:k+kb))
+  if(fmr_max>0)call smear('grav')
 
-       grvphi(il:ir,jl:jr,kl:kr) = &
-                  sum_global_array(grvphi,i,i,j,j+jb,k,k+kb, weight=dvol) / vol
-       grvpsi(il:ir,jl:jr,kl:kr) = &
-                  sum_global_array(grvpsi,i,i,j,j+jb,k,k+kb, weight=dvol) / vol
-
-      end do
-     end do
-    end do
-   end do
-  end if
-!$omp end single
 ! -----------------------------------------------------------------------------
 
  end do
 
 ! Damping of grvpsi by separation of variables
-!$omp do private(i,j,k) collapse(3)
+!$omp parallel do private(i,j,k) collapse(3)
  do k = ks, ke
   do j = js, je
    do i = is, ie
@@ -144,9 +121,7 @@ subroutine hyperbolic_gravity_step(cgrav_now,cgrav_old,dtg)
    end do
   end do
  end do
-!$omp end do
-
-!$omp end parallel
+!$omp end parallel do
 
 end subroutine hyperbolic_gravity_step
 

--- a/src/profiler.f90
+++ b/src/profiler.f90
@@ -2,7 +2,7 @@ module profiler_mod
  implicit none
 
  public:: init_profiler,profiler_output1,start_clock,stop_clock,reset_clock
- integer,parameter:: n_wt=25 ! number of profiling categories
+ integer,parameter:: n_wt=26 ! number of profiling categories
  real(8):: wtime(0:n_wt),wtime_max(0:n_wt),wtime_min(0:n_wt),wtime_avg(0:n_wt),imbalance(0:n_wt)
  integer,parameter:: &
   wtini=1 ,& ! initial conditions
@@ -22,14 +22,15 @@ module profiler_mod
   wtgbn=15,& ! gravbound
   wtpoi=16,& ! Poisson solver
   wthyp=17,& ! hyperbolic self-gravity
-  wtsho=18,& ! shockfind
-  wtrad=19,& ! radiation
-  wtopc=20,& ! opacity
-  wtrfl=21,& ! radiative flux
-  wtsnk=22,& ! sink particles
-  wtout=23,& ! output
-  wtmpi=24,& ! mpi exchange
-  wtwai=25,& ! mpi wait
+  wtgsm=18,& ! gravity smearing
+  wtsho=19,& ! shockfind
+  wtrad=20,& ! radiation
+  wtopc=21,& ! opacity
+  wtrfl=22,& ! radiative flux
+  wtsnk=23,& ! sink particles
+  wtout=24,& ! output
+  wtmpi=25,& ! mpi exchange
+  wtwai=26,& ! mpi wait
   wttot=0    ! total
  integer,public:: parent(0:n_wt),maxlbl
  character(len=30),public:: routine_name(0:n_wt)
@@ -70,6 +71,7 @@ subroutine init_profiler
  parent(wtgbn) = wtgrv ! gravbound
  parent(wtpoi) = wtgrv ! Poisson solver
  parent(wthyp) = wtgrv ! hyperbolic self-gravity
+ parent(wtgsm) = wtgrv ! gravity smearing
  parent(wtout) = wtlop ! output
  parent(wtsho) = wtlop ! shockfind
  parent(wtrad) = wtlop ! radiation
@@ -98,6 +100,7 @@ subroutine init_profiler
  routine_name(wtgbn) = 'Gravbound'   ! gravbound
  routine_name(wtpoi) = 'MICCG'       ! Poisson solver
  routine_name(wthyp) = 'Hyperbolic'  ! hyperbolic self-gravity
+ routine_name(wtgsm) = 'Grav smear'  ! gravity smearing
  routine_name(wtout) = 'Output'      ! output
  routine_name(wtsho) = 'Shockfind'   ! shockfind
  routine_name(wtrad) = 'Radiation'   ! radiation

--- a/src/rungekutta.f90
+++ b/src/rungekutta.f90
@@ -88,7 +88,7 @@ contains
 
   call stop_clock(wtrng)
 
-  call smear
+  call smear('hydro')
 
   call start_clock(wteos)
   call primitive

--- a/src/smear.f90
+++ b/src/smear.f90
@@ -1,8 +1,79 @@
 module smear_mod
  implicit none
 
- integer:: nsmear
+ public:: smear_setup,smear
+ private:: angular_smear,angular_smear_global
+
+ integer,public:: nsmear
+ integer,allocatable,public:: block_j(:),block_k(:)
+ real(8),allocatable,private:: dvol_block(:)
+
 contains
+
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+!
+!                          SUBROUTINE SMEAR_SETUP
+!
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+! PURPOSE: To set up effective grid for nested-grid-like feature
+
+ subroutine smear_setup
+
+  use grid,only:is_global,js_global,je_global,ks_global,ke_global,&
+                fmr_max,fmr_lvl,crdnt,dvol
+
+  integer:: n,i,j,k,jb,kb
+
+!-----------------------------------------------------------------------------
+
+  fmr_lvl(0) = 0
+
+  if(crdnt==2)then
+
+! Determine block structure for each level
+   allocate(block_j(1:fmr_max))
+   block_j = 0
+   allocate(block_k,source=block_j)
+
+   do n = 1, fmr_max
+    if(fmr_lvl(n)==0)cycle
+    if(n==1)then
+     block_j(n) = je_global-js_global+1
+     block_k(n) = ke_global-ks_global+1
+    else
+     block_j(n) = min(2**(fmr_max-n+1),je_global-js_global+1)
+     block_k(n) = min(2**(fmr_max-n+1),ke_global-ks_global+1)
+    end if
+   end do
+
+! Count number of smeared effective cells
+   nsmear = fmr_lvl(1)
+   do n = 2, fmr_max
+    nsmear = nsmear + fmr_lvl(n) &
+                      * (je_global-js_global+1)/block_j(n) &
+                      * (ke_global-ks_global+1)/block_k(n)
+   end do
+
+! Compute effective cell volumes
+   allocate(dvol_block(1:nsmear))
+   do n = 1, fmr_max
+    if(fmr_lvl(n)==0)cycle
+    jb = block_j(n)
+    kb = block_k(n)
+    do k = ks_global, ke_global, kb
+     do j = js_global, je_global, jb
+      do i = is_global+sum(fmr_lvl(0:n-1)), is_global+sum(fmr_lvl(0:n))-1
+       dvol_block(get_id(i,j,k)) = sum(dvol(i,j:j+jb-1,k:k+kb-1))
+      end do
+     end do
+    end do
+   end do
+
+  end if
+
+  return
+ end subroutine smear_setup
 
 !\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 !
@@ -12,128 +83,131 @@ contains
 
 ! PURPOSE: To smear out quantities for nested-grid-like feature
 
-subroutine smear
+ subroutine smear(which)
 
- use grid,only:is_global,js_global,je_global,ks_global,ke_global,&
-               fmr_max,fmr_lvl,dim,crdnt
- use physval
- use composition_mod
- use profiler_mod
- use mpi_domain,only:fully_my_domain
- use mpi_utils,only:allreduce_mpi
+  use grid,only:is_global,js_global,je_global,ks_global,ke_global,&
+                fmr_max,fmr_lvl,dim,crdnt
+  use profiler_mod
+  use mpi_domain,only:fully_my_domain
+  use mpi_utils,only:allreduce_mpi
 
- implicit none
-
- integer:: i,j,k,n,jb,kb
- integer,allocatable:: smeared(:)
+  character(len=*),intent(in):: which
+  integer:: i,j,k,n,jb,kb,wtind
+  integer,allocatable:: smeared(:)
 
 !-----------------------------------------------------------------------------
 
- if(fmr_max==0.or.dim==1)return
+  if(fmr_max==0.or.dim==1)return
 
 ! Average out central cells in spherical coordinates
 ! -> This avoids severe Courant conditions at the centre.
 
- call start_clock(wtsmr)
+  select case(which)
+  case('hydro')
+   wtind = wtsmr
+  case('grav')
+   wtind = wtgsm
+  end select
 
- if(crdnt==2)then
+  call start_clock(wtind)
 
-! Count number of smeared effective cells
-  nsmear = fmr_lvl(1)
-  do n = 2, fmr_max
-   nsmear = nsmear + fmr_lvl(n) &
-                     * max(1,(je_global-js_global+1)/2**(fmr_max-n+1)) &
-                     * max(1,(ke_global-ks_global+1)/2**(fmr_max-n+1))
-  end do
+  if(crdnt==2)then
 
-  allocate( smeared(1:nsmear) )
-  smeared = 0
+   allocate( smeared(1:nsmear) )
+   smeared = 0
 
 ! First sweep
-  do n = 1, fmr_max
-   if(fmr_lvl(n)==0)cycle
-   if(n==1)then
-    jb=je_global-js_global+1; kb=ke_global-ks_global+1
-   else
-    jb=min(2**(fmr_max-n+1),je_global) ; kb=min(2**(fmr_max-n+1),ke_global)
-   end if
-!$omp parallel do private(i,j,k) collapse(3)
-   do k = ks_global, ke_global, kb
-    do j = js_global, je_global, jb
-     do i = is_global+sum(fmr_lvl(0:n-1)), is_global+sum(fmr_lvl(0:n))-1
-      if(fully_my_domain(i,j,k,0,jb,kb))then
-       call angular_smear(i,j,j+jb-1,k,k+kb-1)
-       smeared(get_id(i,j,k)) = 1
-      end if
-     end do
-    end do
-   end do
-!$omp end parallel do
-  end do
-
-  call allreduce_mpi('sum',smeared)
-
-! Second sweep (for effective cells that span over multiple MPI ranks)
-  if(minval(smeared)==0)then
    do n = 1, fmr_max
     if(fmr_lvl(n)==0)cycle
-    if(n==1)then
-     jb=je_global-js_global+1; kb=ke_global-ks_global+1
-    else
-     jb=min(2**(fmr_max-n+1),je_global) ; kb=min(2**(fmr_max-n+1),ke_global)
-    end if
+    jb = block_j(n)
+    kb = block_k(n)
+!$omp parallel do private(i,j,k) collapse(3)
     do k = ks_global, ke_global, kb
      do j = js_global, je_global, jb
       do i = is_global+sum(fmr_lvl(0:n-1)), is_global+sum(fmr_lvl(0:n))-1
-       if(smeared(get_id(i,j,k))==0)then
-        call angular_smear_global(i,j,j+jb-1,k,k+kb-1)
+       if(fully_my_domain(i,j,k,0,jb,kb))then
+        select case(which)
+        case('hydro')
+         call angular_smear(i,j,j+jb-1,k,k+kb-1)
+        case('grav')
+         call angular_smear_grav(i,j,j+jb-1,k,k+kb-1)
+        end select
+        smeared(get_id(i,j,k)) = 1
        end if
       end do
      end do
     end do
+!$omp end parallel do
    end do
+
+   call allreduce_mpi('sum',smeared)
+
+! Second sweep (for effective cells that span over multiple MPI ranks)
+   if(minval(smeared)==0)then
+    do n = 1, fmr_max
+     if(fmr_lvl(n)==0)cycle
+     jb = block_j(n)
+     kb = block_k(n)
+     do k = ks_global, ke_global, kb
+      do j = js_global, je_global, jb
+       do i = is_global+sum(fmr_lvl(0:n-1)), is_global+sum(fmr_lvl(0:n))-1
+        if(smeared(get_id(i,j,k))==0)then
+         select case(which)
+         case('hydro')
+          call angular_smear_global(i,j,j+jb-1,k,k+kb-1)
+         case('grav')
+          call angular_smear_grav_global(i,j,j+jb-1,k,k+kb-1)
+         end select
+        end if
+       end do
+      end do
+     end do
+    end do
+   end if
+
+   deallocate(smeared)
+
   end if
 
- end if
+  call stop_clock(wtind)
 
- call stop_clock(wtsmr)
-
- return
-end subroutine smear
+  return
+ end subroutine smear
 
 ! Get smeared cell id from i,j,k \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
-function get_id(i,j,k) result(id)
+ function get_id(i,j,k) result(id)
 
- use grid,only:is_global,js_global,je_global,ks_global,ke_global,&
-               fmr_max,fmr_lvl
+  use grid,only:is_global,js_global,je_global,ks_global,ke_global,&
+                fmr_max,fmr_lvl
 
- integer,intent(in):: i,j,k
- integer:: n, id, jn,kn
+  integer,intent(in):: i,j,k
+  integer:: n, id, jn,kn
 
- do n = 1, fmr_max
-  if(i<=is_global+sum(fmr_lvl(0:n))-1)exit
+  do n = 1, fmr_max
+   if(i<=is_global+sum(fmr_lvl(0:n))-1)exit
+
+   if(n==1)then
+    id = fmr_lvl(1)
+   else
+    jn = (je_global-js_global+1)/block_j(n)
+    kn = (ke_global-ks_global+1)/block_k(n)
+    id = id + fmr_lvl(n)*jn*kn
+   end if
+  end do
+
+  if(n>fmr_max)error stop 1
 
   if(n==1)then
-   id = fmr_lvl(1)
+   id = i
   else
-   jn = max(1,(je_global-js_global+1)/2**(fmr_max-n+1))
-   kn = max(1,(ke_global-ks_global+1)/2**(fmr_max-n+1))
-   id = id + fmr_lvl(n)*jn*kn
+   jn = (je_global-js_global+1)/block_j(n)
+   kn = (ke_global-ks_global+1)/block_k(n)
+   id = id + (i-sum(fmr_lvl(0:n-1))-1) * jn * kn &
+           + int(j/block_j(n)) + int(k/block_k(n))*jn + 1
   end if
- end do
- if(n>fmr_max)error stop 1
 
- if(n==1)then
-  id = i
- else
-  jn = max(1,(je_global-js_global+1)/2**(fmr_max-n+1))
-  kn = max(1,(ke_global-ks_global+1)/2**(fmr_max-n+1))
-  id = id + (i-sum(fmr_lvl(0:n-1))-1) * jn * kn &
-          + (j/2**(fmr_max-n+1)) + (k/2**(fmr_max-n+1))*jn + 1
- end if
-
-return
-end function get_id
+  return
+ end function get_id
 
 !\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 !
@@ -141,7 +215,7 @@ end function get_id
 !
 !\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
-! PURPOSE: Average out quantities over several cells in the angular direction
+! PURPOSE: Average out hydro quantities over several cells in the jk direction
 
  subroutine angular_smear(i,js_,je_,ks_,ke_)
 
@@ -160,7 +234,7 @@ end function get_id
 
 !-----------------------------------------------------------------------------
 
-  vol = sum(dvol(i,js_:je_,ks_:ke_))
+  vol = dvol_block(get_id(i,js_,ks_))
   mtot = sum(u(i,js_:je_,ks_:ke_,icnt)*dvol(i,js_:je_,ks_:ke_))
 
   if(compswitch>=2)then
@@ -181,10 +255,7 @@ end function get_id
     tempsum = momtot + element
     compen = get_compensation(element,tempsum,momtot)
     momtot = tempsum ! add up momenta using the Kahan algorithm
-!!$     u(i,j,k,imo1) = vcar(1)
-!!$     u(i,j,k,imo2) = vcar(2)
-!!$     u(i,j,k,imo3) = vcar(3)
-!!$     momtot = momtot + vcar*dvol(i,j,k)
+
     etot = etot + u(i,j,k,iene)*dvol(i,j,k)! add up energy
     if(gravswitch>0)& ! and gravitational energy
      etot = etot + u(i,j,k,icnt)*totphi(i,j,k)*dvol(i,j,k)
@@ -210,6 +281,35 @@ end function get_id
   u(i,js_:je_,ks_:ke_,iene) = etot / vol
 
  end subroutine angular_smear
+
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+!
+!                      SUBROUTINE ANGULAR_SMEAR_GRAV
+!
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+! PURPOSE: Average out gravity quantities over several cells in the jk direction
+
+ subroutine angular_smear_grav(i,js_,je_,ks_,ke_)
+
+  use grid,only:dvol
+  use gravmod,only:grvphi,grvpsi
+
+  implicit none
+
+  integer,intent(in)::i,js_,je_,ks_,ke_
+  real(8):: vol
+
+!-----------------------------------------------------------------------------
+
+  vol = dvol_block(get_id(i,js_,ks_))
+
+  grvphi(i,js_:je_,ks_:ke_) = sum( grvphi(i,js_:je_,ks_:ke_) &
+                                 * dvol  (i,js_:je_,ks_:ke_) ) / vol
+  grvpsi(i,js_:je_,ks_:ke_) = sum( grvpsi(i,js_:je_,ks_:ke_) &
+                                 * dvol  (i,js_:je_,ks_:ke_) ) / vol
+
+ end subroutine angular_smear_grav
 
 !\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 !
@@ -244,7 +344,7 @@ end function get_id
   kl = max(ks_,ks); kr = min(ke_,ke)
   overlap = partially_my_domain(i,js_,ks_,0,je_-js_+1,ke_-ks_+1)
 
-  vol = sum(dvol(i,js_:je_,ks_:ke_))
+  vol = dvol_block(get_id(i,js_,ks_))
   mtot = sum_global_array(u,i,i,js_,je_,ks_,ke_,icnt,weight=dvol)
 
   if(compswitch>=2)then
@@ -360,20 +460,56 @@ end function get_id
 !!$   end do
 !!$  end do
 
- return
-end subroutine angular_smear_global
+  return
+ end subroutine angular_smear_global
 
-pure elemental function get_compensation(y,t,s) result(c)
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+!
+!                      SUBROUTINE ANGULAR_SMEAR_GRAV
+!
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+! PURPOSE: Average out gravity quantities over several cells in the jk direction
+
+ subroutine angular_smear_grav_global(i,js_,je_,ks_,ke_)
+
+  use grid,only:js,je,ks,ke,dvol
+  use gravmod,only:grvphi,grvpsi
+  use mpi_domain,only:sum_global_array,partially_my_domain
+
+  implicit none
+
+  integer,intent(in)::i,js_,je_,ks_,ke_
+  integer:: jl,jr,kl,kr
+  real(8):: vol
+  logical:: overlap
+
+!-----------------------------------------------------------------------------
+
+  jl = max(js_,js); jr = min(je_,je)
+  kl = max(ks_,ks); kr = min(ke_,ke)
+  overlap = partially_my_domain(i,js_,ks_,0,je_-js_+1,ke_-ks_+1)
+
+  vol = dvol_block(get_id(i,js_,ks_))
+
+  grvphi(i,jl:jr,kl:kr) = &
+             sum_global_array(grvphi,i,i,js_,je_,ks_,ke_,weight=dvol) / vol
+  grvpsi(i,jl:jr,kl:kr) = &
+             sum_global_array(grvpsi,i,i,js_,je_,ks_,ke_,weight=dvol) / vol
+
+ end subroutine angular_smear_grav_global
+
+ pure elemental function get_compensation(y,t,s) result(c)
 ! Get compensation term for the Kahan-Babuska-Neumaier method
- real(8),intent(in):: y,t,s
- real(8):: c
+  real(8),intent(in):: y,t,s
+  real(8):: c
 
- if(abs(s)>=abs(y))then
-  c = (s-t)+y
- else
-  c = (y-t)+s
- end if
+  if(abs(s)>=abs(y))then
+   c = (s-t)+y
+  else
+   c = (y-t)+s
+  end if
 
-end function get_compensation
+ end function get_compensation
 
 end module smear_mod

--- a/src/smear.f90
+++ b/src/smear.f90
@@ -465,7 +465,7 @@ contains
 
 !\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 !
-!                      SUBROUTINE ANGULAR_SMEAR_GRAV
+!                   SUBROUTINE ANGULAR_SMEAR_GRAV_GLOBAL
 !
 !\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
@@ -481,21 +481,21 @@ contains
 
   integer,intent(in)::i,js_,je_,ks_,ke_
   integer:: jl,jr,kl,kr
-  real(8):: vol
-  logical:: overlap
+  real(8):: vol, phiave, psiave
 
 !-----------------------------------------------------------------------------
 
-  jl = max(js_,js); jr = min(je_,je)
-  kl = max(ks_,ks); kr = min(ke_,ke)
-  overlap = partially_my_domain(i,js_,ks_,0,je_-js_+1,ke_-ks_+1)
-
   vol = dvol_block(get_id(i,js_,ks_))
 
-  grvphi(i,jl:jr,kl:kr) = &
-             sum_global_array(grvphi,i,i,js_,je_,ks_,ke_,weight=dvol) / vol
-  grvpsi(i,jl:jr,kl:kr) = &
-             sum_global_array(grvpsi,i,i,js_,je_,ks_,ke_,weight=dvol) / vol
+  phiave = sum_global_array(grvphi,i,i,js_,je_,ks_,ke_,weight=dvol) / vol
+  psiave = sum_global_array(grvpsi,i,i,js_,je_,ks_,ke_,weight=dvol) / vol
+
+  if(partially_my_domain(i,js_,ks_,0,je_-js_+1,ke_-ks_+1))then
+   jl = max(js_,js); jr = min(je_,je)
+   kl = max(ks_,ks); kr = min(ke_,ke)
+   grvphi(i,jl:jr,kl:kr) = phiave
+   grvpsi(i,jl:jr,kl:kr) = psiave
+  end if
 
  end subroutine angular_smear_grav_global
 

--- a/src/tools.f90
+++ b/src/tools.f90
@@ -14,7 +14,7 @@ contains
 subroutine tools
 
  use settings,only:crdnt,gravswitch,radswitch,include_cooling,eostype
- use grid,only:coscyl,gis,gie,gks,gke,cosc,is,ie,js,je,ks,ke,fmr_lvl
+ use grid,only:coscyl,gis,gie,gks,gke,cosc,is,ie,js,je,ks,ke,fmr_max
  use physval,only:gamma,imu,muconst
  use gravmod,only:llmax,Plc,Pl
  use constants,only:fac_egas,fac_pgas,kbol,amu
@@ -22,6 +22,7 @@ subroutine tools
  use cooling_mod,only:cooling_setup
  use gravity_mod,only:gravsetup
  use radiation_mod,only:radiation_setup
+ use smear_mod,only:smear_setup
 
  integer:: i,j,k,ll
 
@@ -137,15 +138,15 @@ subroutine tools
 ! Set cooling parameters %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
  if(include_cooling) call cooling_setup
 
-! Set Fixed Mesh Refinement parameters %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
- fmr_lvl(0) = 0
-
 ! Set gravity parameters %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
  if(gravswitch>0) call gravsetup
 
 ! Set radiation parameters %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
  if(radswitch>0) call radiation_setup
 
+! Set smearing parameters %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+ if(fmr_max>0) call smear_setup
+ 
 return
 end subroutine tools
 


### PR DESCRIPTION
In a previous pull request #76, I forgot to apply the same changes to the gravity smearing.
Here, I do the same optimization for gravity smearing and also introduced a new variable `dvol_block`. With this fix, we may not need to make `dvol` as a global variable any more. 