### PR TITLE
MPI I/O error fix

### DIFF
--- a/src/allocations.f90
+++ b/src/allocations.f90
@@ -14,6 +14,7 @@ contains
 subroutine allocations
 
  use settings
+ use derived_types,only:null_sink
  use grid
  use physval
  use gravmod
@@ -283,6 +284,9 @@ subroutine allocations
  if(include_sinks)then
   allocate(snkphi,mold=d)
   allocate(sink(1:nsink))
+  do n = 1, nsink
+   call null_sink(sink(n))
+  end do
  end if
 
  return

--- a/src/allocations.f90
+++ b/src/allocations.f90
@@ -39,7 +39,7 @@ subroutine allocations
  allocate(detg1(is_global-2:ie_global+2))
  allocate(idetg1,sx1,g22,mold=detg1)
 
- allocate(scot(js-2:je+2))
+ allocate(scot(js_global-2:je_global+2))
  allocate(sisin,mold=scot)
 
  allocate(detg2(is_global-2:ie_global+2,js_global-2:je_global+2))

--- a/src/gridset.f90
+++ b/src/gridset.f90
@@ -360,7 +360,7 @@ subroutine gridset
     if    (je_global==js_global)then
      jetmp=1
     elseif(je_global>=js_global+1)then
-     jetmp=je_global
+     jetmp=je_global-js_global+1
     endif
     dxi2(js_global-2:je_global+2) = xi2e / dble(jetmp)
    case(2) mesh_sph2 ! user specified mesh
@@ -450,6 +450,16 @@ subroutine gridset
 
   xi1e = xi1(ie)
   xi1s = xi1(is-1)
+
+  if(crdnt==2)then
+   allocate( sinc, sini, cosc, cosi, mold=x2 )
+   do j = js_global-2, je_global+2
+    sinc(j)=real(sin(real(x2 (j),kind=16)),kind=8)
+    sini(j)=real(sin(real(xi2(j),kind=16)),kind=8)
+    cosc(j)=real(cos(real(x2 (j),kind=16)),kind=8)
+    cosi(j)=real(cos(real(xi2(j),kind=16)),kind=8)
+   end do
+  end if
 
  end if
 

--- a/src/iotest.f90
+++ b/src/iotest.f90
@@ -83,12 +83,16 @@ module iotest_mod
         sink(i)%mass = 1.d0*i
         sink(i)%softfac = 10.d0*i
         sink(i)%lsoft = 100.d0*i
-        sink(i)%locres = 1000.d0*i
-        sink(i)%dt = 10000.d0*i
+        sink(i)%laccr = 1000.d0*i
+        sink(i)%locres = 10000.d0*i
+        sink(i)%dt = 100000.d0*i
+        sink(i)%mdot = 1000000.d0*i
         sink(i)%x = (/1.d0*i,10.d0*i,100.d0*i/)
         sink(i)%v = (/2.d0*i,20.d0*i,200.d0*i/)
         sink(i)%a = (/3.d0*i,30.d0*i,300.d0*i/)
         sink(i)%xpol = (/4.d0*i,40.d0*i,400.d0*i/)
+        sink(i)%Jspin = (/5.d0*i,50.d0*i,500.d0*i/)
+        sink(i)%jdot = (/6.d0*i,60.d0*i,600.d0*i/)
       end do
       call open_sinkfile
     endif
@@ -149,12 +153,16 @@ module iotest_mod
       sink(i)%mass = 0.d0
       sink(i)%softfac = 0.d0
       sink(i)%lsoft = 0.d0
+      sink(i)%laccr = 0.d0
       sink(i)%locres = 0.d0
       sink(i)%dt = 0.d0
+      sink(i)%mdot = 0.d0
       sink(i)%x = 0.d0
       sink(i)%v = 0.d0
       sink(i)%a = 0.d0
       sink(i)%xpol = 0.d0
+      sink(i)%Jspin = 0.d0
+      sink(i)%jdot = 0.d0
     end do
 
     ! Read the arrays from file
@@ -238,12 +246,16 @@ module iotest_mod
         err = err + abs(sink(i)%mass - 1.d0*i)
         err = err + abs(sink(i)%softfac - 10.d0*i)
         err = err + abs(sink(i)%lsoft - 100.d0*i)
-        err = err + abs(sink(i)%locres - 1000.d0*i)
-        err = err + abs(sink(i)%dt - 10000.d0*i)
+        err = err + abs(sink(i)%laccr - 1000.d0*i)
+        err = err + abs(sink(i)%locres - 10000.d0*i)
+        err = err + abs(sink(i)%dt - 100000.d0*i)
+        err = err + abs(sink(i)%mdot - 1000000.d0*i)
         err = err + sum(abs(sink(i)%x - (/1.d0*i, 10.d0*i, 100.d0*i/)))
         err = err + sum(abs(sink(i)%v - (/2.d0*i, 20.d0*i, 200.d0*i/)))
         err = err + sum(abs(sink(i)%a - (/3.d0*i, 30.d0*i, 300.d0*i/)))
         err = err + sum(abs(sink(i)%xpol - (/4.d0*i, 40.d0*i, 400.d0*i/)))
+        err = err + sum(abs(sink(i)%Jspin - (/5.d0*i, 50.d0*i, 500.d0*i/)))
+        err = err + sum(abs(sink(i)%jdot - (/6.d0*i, 60.d0*i, 600.d0*i/)))
         if (err > 0.d0) then
           print*, 'Error in sink array values at i=', i, 'err=', err
           numerr = numerr + 1

--- a/src/iotest.f90
+++ b/src/iotest.f90
@@ -12,6 +12,7 @@ module iotest_mod
 
   subroutine iotest
     use mpi_utils
+    use derived_types,only:null_sink
     use grid
     use physval
     use output_mod
@@ -147,22 +148,7 @@ module iotest_mod
     species = ''
 
     do i = 1, size(sink)
-      sink(i)%i = 0
-      sink(i)%j = 0
-      sink(i)%k = 0
-      sink(i)%mass = 0.d0
-      sink(i)%softfac = 0.d0
-      sink(i)%lsoft = 0.d0
-      sink(i)%laccr = 0.d0
-      sink(i)%locres = 0.d0
-      sink(i)%dt = 0.d0
-      sink(i)%mdot = 0.d0
-      sink(i)%x = 0.d0
-      sink(i)%v = 0.d0
-      sink(i)%a = 0.d0
-      sink(i)%xpol = 0.d0
-      sink(i)%Jspin = 0.d0
-      sink(i)%jdot = 0.d0
+     call null_sink(sink(i))
     end do
 
     ! Read the arrays from file

--- a/src/modules.f90
+++ b/src/modules.f90
@@ -22,6 +22,7 @@ module settings
  character(len=5):: dt_unit
  real(8):: grverr, cgerr, eoserr, HGfac, hgcfl, alphagrv
  integer:: imesh, jmesh, kmesh
+ integer:: nsink
 ! test tolerance
  real(8):: test_tol
 ! switches
@@ -164,9 +165,32 @@ module derived_types
 
  type sink_prop
   sequence
-  integer:: i,j,k
+  integer:: i,j,k,pad ! pad is added to align memory for 64-bit machines
   real(8):: mass, softfac, lsoft, laccr, locres, dt, mdot
   real(8),dimension(1:3):: x,v,a,xpol,Jspin,jdot
  end type sink_prop
+
+contains
+
+ subroutine null_sink(sink)
+  type(sink_prop),intent(out):: sink
+  sink%i=0
+  sink%j=0
+  sink%k=0
+  sink%pad=0
+  sink%mass=0d0
+  sink%softfac=0d0
+  sink%lsoft=0d0
+  sink%laccr=0d0
+  sink%locres=0d0
+  sink%dt=0d0
+  sink%mdot=0d0
+  sink%x=0d0
+  sink%v=0d0
+  sink%a=0d0
+  sink%xpol=0d0
+  sink%Jspin=0d0
+  sink%jdot=0d0
+ end subroutine null_sink
 
 end module derived_types

--- a/src/mpi_domain.F90
+++ b/src/mpi_domain.F90
@@ -503,12 +503,17 @@ module mpi_domain
       offsets = offsets - offsets(1)
 
       ! Set the blocklengths (number of elements in each block)
-      blocklengths = (/1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 3, 3, 3/)
+      blocklengths = [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 3, 3, 3 ]
 
       ! Set the types (type of each block)
-      types = (/MPI_INTEGER, MPI_INTEGER, MPI_INTEGER, \
-                MPI_DOUBLE_PRECISION, MPI_DOUBLE_PRECISION, MPI_DOUBLE_PRECISION, MPI_DOUBLE_PRECISION, MPI_DOUBLE_PRECISION, MPI_DOUBLE_PRECISION, MPI_DOUBLE_PRECISION, \
-                MPI_DOUBLE_PRECISION, MPI_DOUBLE_PRECISION, MPI_DOUBLE_PRECISION, MPI_DOUBLE_PRECISION, MPI_DOUBLE_PRECISION, MPI_DOUBLE_PRECISION/)
+      types = [ MPI_INTEGER, MPI_INTEGER, MPI_INTEGER, \
+                MPI_DOUBLE_PRECISION, MPI_DOUBLE_PRECISION, \
+                MPI_DOUBLE_PRECISION, MPI_DOUBLE_PRECISION, \
+                MPI_DOUBLE_PRECISION, MPI_DOUBLE_PRECISION, \
+                MPI_DOUBLE_PRECISION, \
+                MPI_DOUBLE_PRECISION, MPI_DOUBLE_PRECISION, \
+                MPI_DOUBLE_PRECISION, MPI_DOUBLE_PRECISION, \
+                MPI_DOUBLE_PRECISION, MPI_DOUBLE_PRECISION ]
 
       ! Create the custom datatype
       call MPI_Type_create_struct(nattr, blocklengths, offsets, types, mpi_type_sink_prop, ierr)

--- a/src/mpi_domain.F90
+++ b/src/mpi_domain.F90
@@ -473,40 +473,43 @@ module mpi_domain
 
    subroutine create_sink_type_mpi
 #ifdef MPI
-      use mpi_utils, only: mpi_type_sink_prop
-      use derived_types, only: sink_prop
+      use settings,only: nsink
+      use mpi_utils, only: mpi_type_sink_prop, mpi_type_sink_prop_array
+      use derived_types, only: sink_prop,null_sink
       type(sink_prop) :: sink
-      integer, parameter :: nattr = 16
+      integer, parameter :: nattr = 17
       integer, dimension(nattr) :: types, blocklengths
       integer(kind=MPI_ADDRESS_KIND), dimension(nattr) :: offsets
       integer :: ierr
 
+      call null_sink(sink)
       ! Get the addresses of each component of sink_prop
-      call MPI_Get_address(sink%i, offsets(1), ierr)
-      call MPI_Get_address(sink%j, offsets(2), ierr)
-      call MPI_Get_address(sink%k, offsets(3), ierr)
-      call MPI_Get_address(sink%mass, offsets(4), ierr)
-      call MPI_Get_address(sink%softfac, offsets(5), ierr)
-      call MPI_Get_address(sink%lsoft, offsets(6), ierr)
-      call MPI_Get_address(sink%laccr, offsets(7), ierr)
-      call MPI_Get_address(sink%locres, offsets(8), ierr)
-      call MPI_Get_address(sink%dt, offsets(9), ierr)
-      call MPI_Get_address(sink%mdot, offsets(10), ierr)
-      call MPI_Get_address(sink%x, offsets(11), ierr)
-      call MPI_Get_address(sink%v, offsets(12), ierr)
-      call MPI_Get_address(sink%a, offsets(13), ierr)
-      call MPI_Get_address(sink%xpol, offsets(14), ierr)
-      call MPI_Get_address(sink%Jspin, offsets(15), ierr)
-      call MPI_Get_address(sink%jdot, offsets(16), ierr)
+      call MPI_Get_address(sink%i      , offsets( 1), ierr)
+      call MPI_Get_address(sink%j      , offsets( 2), ierr)
+      call MPI_Get_address(sink%k      , offsets( 3), ierr)
+      call MPI_Get_address(sink%pad    , offsets( 4), ierr)
+      call MPI_Get_address(sink%mass   , offsets( 5), ierr)
+      call MPI_Get_address(sink%softfac, offsets( 6), ierr)
+      call MPI_Get_address(sink%lsoft  , offsets( 7), ierr)
+      call MPI_Get_address(sink%laccr  , offsets( 8), ierr)
+      call MPI_Get_address(sink%locres , offsets( 9), ierr)
+      call MPI_Get_address(sink%dt     , offsets(10), ierr)
+      call MPI_Get_address(sink%mdot   , offsets(11), ierr)
+      call MPI_Get_address(sink%x      , offsets(12), ierr)
+      call MPI_Get_address(sink%v      , offsets(13), ierr)
+      call MPI_Get_address(sink%a      , offsets(14), ierr)
+      call MPI_Get_address(sink%xpol   , offsets(15), ierr)
+      call MPI_Get_address(sink%Jspin  , offsets(16), ierr)
+      call MPI_Get_address(sink%jdot   , offsets(17), ierr)
 
       ! Compute offsets as relative to the start of sink
       offsets = offsets - offsets(1)
 
       ! Set the blocklengths (number of elements in each block)
-      blocklengths = [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 3, 3, 3 ]
+      blocklengths = [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 3, 3, 3 ]
 
       ! Set the types (type of each block)
-      types = [ MPI_INTEGER, MPI_INTEGER, MPI_INTEGER, \
+      types = [ MPI_INTEGER, MPI_INTEGER, MPI_INTEGER, MPI_INTEGER, \
                 MPI_DOUBLE_PRECISION, MPI_DOUBLE_PRECISION, \
                 MPI_DOUBLE_PRECISION, MPI_DOUBLE_PRECISION, \
                 MPI_DOUBLE_PRECISION, MPI_DOUBLE_PRECISION, \
@@ -518,6 +521,10 @@ module mpi_domain
       ! Create the custom datatype
       call MPI_Type_create_struct(nattr, blocklengths, offsets, types, mpi_type_sink_prop, ierr)
       call MPI_Type_commit(mpi_type_sink_prop, ierr)
+
+      call MPI_Type_contiguous(nsink, mpi_type_sink_prop, mpi_type_sink_prop_array, ierr)
+      call MPI_Type_commit(mpi_type_sink_prop_array, ierr)
+
 #endif
    end subroutine create_sink_type_mpi
 

--- a/src/mpi_utils.F90
+++ b/src/mpi_utils.F90
@@ -14,7 +14,7 @@ module mpi_utils
   public :: allreduce_mpi
 
   integer :: myrank, nprocs
-  integer :: mpi_subarray_default, mpi_subarray_spc, mpi_subarray_gravity, mpi_type_sink_prop, mpi_subarray_extgrtv
+  integer :: mpi_subarray_default, mpi_subarray_spc, mpi_subarray_gravity, mpi_type_sink_prop, mpi_type_sink_prop_array, mpi_subarray_extgrtv
 
   contains
 

--- a/src/readbin.f90
+++ b/src/readbin.f90
@@ -23,7 +23,6 @@ subroutine readbin(filename)
  use composition_mod
  use gravmod
  use sink_mod,only:sink
- use mpi_utils,only:myrank
 
  character(len=*),intent(in):: filename
  integer:: un

--- a/src/readbin.f90
+++ b/src/readbin.f90
@@ -22,7 +22,8 @@ subroutine readbin(filename)
  use pressure_mod
  use composition_mod
  use gravmod
- use sink_mod,only:nsink,sink
+ use sink_mod,only:sink
+ use mpi_utils,only:myrank
 
  character(len=*),intent(in):: filename
  integer:: un
@@ -37,11 +38,11 @@ subroutine readbin(filename)
  call read_dummy_recordmarker(un)
 
  call read_dummy_recordmarker(un)
- call read_var(un, d, is, ie, js, je, ks, ke)
+ call read_var(un,  d, is, ie, js, je, ks, ke)
  call read_var(un, v1, is, ie, js, je, ks, ke)
  call read_var(un, v2, is, ie, js, je, ks, ke)
  call read_var(un, v3, is, ie, js, je, ks, ke)
- call read_var(un, e, is, ie, js, je, ks, ke)
+ call read_var(un,  e, is, ie, js, je, ks, ke)
  call read_dummy_recordmarker(un)
 
  if(eostype>=1)then
@@ -72,9 +73,9 @@ subroutine readbin(filename)
 
  if(mag_on)then
   call read_dummy_recordmarker(un)
-  call read_var(un, b1, is, ie, js, je, ks, ke)
-  call read_var(un, b2, is, ie, js, je, ks, ke)
-  call read_var(un, b3, is, ie, js, je, ks, ke)
+  call read_var(un, b1 , is, ie, js, je, ks, ke)
+  call read_var(un, b2 , is, ie, js, je, ks, ke)
+  call read_var(un, b3 , is, ie, js, je, ks, ke)
   call read_var(un, phi, is, ie, js, je, ks, ke)
   call read_dummy_recordmarker(un)
  end if

--- a/src/setup.f90
+++ b/src/setup.f90
@@ -158,7 +158,6 @@ subroutine read_parameters(filename)
  use settings
  use grid
  use physval
- use sink_mod,only:nsink
 
  integer:: ui,istat
  character(len=*),intent(in)::filename

--- a/src/sinks.f90
+++ b/src/sinks.f90
@@ -1,10 +1,10 @@
 module sink_mod
 
+ use settings,only:nsink
  use derived_types,only:sink_prop
 
  implicit none
 
- integer,public:: nsink
  type(sink_prop),allocatable,public:: sink(:)
  real(8),allocatable,public:: snkphi(:,:,:)
 


### PR DESCRIPTION
For some reason, the MPI output is not working on OzStar.
When compared to a serial run, the MPI output is roughly half the size.
This is my branch attempting to fix this.