### PR TITLE
Separate out ascii output

### DIFF
--- a/para/parameters_base
+++ b/para/parameters_base
@@ -8,6 +8,7 @@
 	  x1min=0d0 x2min=0 x3min=0d0
 	  fmr_max=0 fmr_lvl(1:20)=0 /
 
+! outdir : Output directory name
 ! outstyle/endstyle : time=1, timestep=2
 ! tnlim : Upper limit for number of timesteps (only when outstyle=2)
 ! t_end : Upper limit for physical time (only when outstyle=1)
@@ -17,15 +18,16 @@
 ! dt_unit : Give name of dt_unit (current options are 'ns,'ms,'s','min','ks','hr','d','yr')
 ! sigfig : How many significant figures in output values
 ! outres : Resolution of output grid (1 means output everything, 2 means every 2 grid points, etc)
+! output_ascii : Output plt file (some machines are extremely slow at writing ascii files, especially in MPI)
 ! write_other_vel : Set to .true. if 2.5D
 ! write_shock : Output shock switch
 ! write_evo : Output evofile
 ! write_other_slice : Output an alternative slice for 3D
 ! write_temp : Output temperature (only relevant for eostype=0)
 ! write_mc : Output mass coordinates (only relevant for crdnt=2)
-&out_con  outstyle=1 endstyle=1
+&out_con  outdir='../../mpi_work/work/data' outstyle=1 endstyle=1
           tnlim=0 t_end=0d0 dt_out=1d0 tn_out=1 tn_evo=10
-          dt_unit='s' sigfig=7 outres=1
+          dt_unit='s' sigfig=7 outres=1 output_ascii=.true.
 	  write_other_vel =.false. write_shock =.false. write_evo=.false.
 	  write_other_slice=.false. write_temp = .false. write_mc=.false. /
 

--- a/para/parameters_base
+++ b/para/parameters_base
@@ -25,7 +25,7 @@
 ! write_other_slice : Output an alternative slice for 3D
 ! write_temp : Output temperature (only relevant for eostype=0)
 ! write_mc : Output mass coordinates (only relevant for crdnt=2)
-&out_con  outdir='../../mpi_work/work/data' outstyle=1 endstyle=1
+&out_con  outdir='data' outstyle=1 endstyle=1
           tnlim=0 t_end=0d0 dt_out=1d0 tn_out=1 tn_evo=10
           dt_unit='s' sigfig=7 outres=1 output_ascii=.true.
 	  write_other_vel =.false. write_shock =.false. write_evo=.false.

--- a/para/parameters_sn2022jli
+++ b/para/parameters_sn2022jli
@@ -26,7 +26,7 @@
 ! write_other_slice : Output an alternative slice for 3D
 &out_con  outstyle=1 endstyle=1
           tnlim=100000 t_end=18000d0 dt_out=1.d2 tn_out=1
-          dt_unit='min' sigfig=7 outres=1
+          dt_unit='min' sigfig=7 outres=1 output_ascii=.false.
 	  write_other_vel =.false. write_shock =.true.
 	  write_evo=.true. write_other_slice=.true. /
 

--- a/src/ascii_output.f90
+++ b/src/ascii_output.f90
@@ -69,7 +69,6 @@ program write_ascii
 
 ! Start initial setup
   call allocations
-  call gridset
 
   outtn = 0
   outtime = 0d0

--- a/src/ascii_output.f90
+++ b/src/ascii_output.f90
@@ -1,0 +1,89 @@
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\!
+!                                                                           !
+!                                                                           !
+!                                                                           !
+!                             PROGRAM HORMONE                               !
+!                                                                           !
+!                                                                           !
+!                                                                           !
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\!
+!                                                                           !
+!    High ORder Magnetohydrodynamic cOde with Numerous Enhancements         !
+!                                                                           !
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\!
+
+! PURPOSE: Main program to solve ideal MHD problems
+
+!############################################################################
+
+program write_ascii
+
+  use mpi_utils
+  use mpi_domain
+  use settings
+  use grid
+  use physval
+  use allocation_mod
+  use tools_mod
+  use checksetup_mod
+  use setup_mod
+  use readbin_mod
+  use output_mod
+  use gridset_mod
+  use profiler_mod
+
+  implicit none
+
+  integer:: outtn
+  real(8):: outtime
+  character(len=70):: file
+
+
+!############################## start program ################################
+
+  in_loop = .false.
+
+  call init_mpi
+
+! Start profiling
+  call init_profiler
+
+! Initial setups -------------------------------------------------------------
+
+  call start_clock(wtini)
+
+  time = 0d0; tn = 0
+
+! Read startfile
+  call read_startfile
+
+! Read default parameter file
+  call read_default
+
+! Reading parameters
+  call read_parameters(parafile)
+  call checksetup
+
+! Decompose domain onto MPI tasks
+  call domain_decomp
+
+! Start initial setup
+  call allocations
+  call gridset
+
+  outtn = 0
+  outtime = 0d0
+  do
+   call set_file_name('bin',outtn,outtime,file)
+   print*,'Reading ',file
+   call readbin(file)
+   call write_plt
+   outtime = outtime + dt_out
+   outtn = outtn + tn_out
+  end do
+
+  call finalize_mpi
+
+!------------------------------- end program ---------------------------------
+
+ end program write_ascii

--- a/src/gravity.f90
+++ b/src/gravity.f90
@@ -164,6 +164,7 @@ subroutine gravity_relax
  use mpi_utils,only:allreduce_mpi
  use mpi_domain,only:myrank
  use gravity_hyperbolic_mod,only:hyperbolic_gravity_step
+ use profiler_mod
 
  real(8):: err
  integer :: grktype_org
@@ -217,6 +218,9 @@ subroutine gravity_relax
 
  ! Reset grktype
  grktype = grktype_org
+
+! Reset clocks
+ call reset_clock(wthyp)
 
 return
 end subroutine gravity_relax

--- a/src/modules.f90
+++ b/src/modules.f90
@@ -30,11 +30,11 @@ module settings
  logical:: include_extgrv, include_particles, include_cooling, mag_on
  logical:: include_extforce, include_sinks, include_accretion, is_test
  logical:: write_other_vel, write_shock, write_evo, write_other_slice
- logical:: write_temp, write_mc
+ logical:: write_temp, write_mc, output_ascii
  logical:: grav_init_other, grav_init_relax
  logical:: in_loop
  character(len=30):: flux_limiter, simtype
- character(len=50):: parafile,extrasfile
+ character(len=50):: parafile,extrasfile, outdir
 
 end module settings
 

--- a/src/output.f90
+++ b/src/output.f90
@@ -1224,6 +1224,7 @@ subroutine profiler_output
  call reduce_clocks_mpi
 
  if (myrank==0) then
+  call get_maxlbl
   write(form1,'("(",i2,"X4a12)")')maxlbl+1
   write(forml,'("(",i2,"a)")')maxlbl+1 + 4*12
 

--- a/src/output.f90
+++ b/src/output.f90
@@ -3,8 +3,8 @@ module output_mod
 
  integer:: ievo,iskf
  public:: output,terminal_output,set_file_name,write_extgrv,evo_output,&
-          scaling_output, write_grid
- private:: write_bin,write_plt,get_header,add_column, &
+          scaling_output,write_grid,write_plt
+ private:: write_bin,get_header,add_column, add_directory_to_filename,&
            write_val,write_vertical_slice
 
  contains
@@ -19,7 +19,7 @@ module output_mod
 
 subroutine output
 
- use settings,only:is_test
+ use settings,only:is_test,output_ascii
  use grid,only:tn
  use profiler_mod
  use mpi_utils,only:barrier_mpi
@@ -41,7 +41,7 @@ subroutine output
  if(tn==0)call write_grid
 
  call write_bin
- call write_plt
+ if(output_ascii)call write_plt
 
 ! Tracer particle outputs
  call write_bpt
@@ -100,7 +100,7 @@ subroutine open_evofile
  use mpi_utils, only:myrank
 
  integer::ierr
- character(len=50):: forma
+ character(len=70):: forma, filename
 
 !-----------------------------------------------------------------------------
 
@@ -108,15 +108,16 @@ subroutine open_evofile
  if(.not.write_evo)return
 
  write(forma,'("(a",i2,")")')sigfig+8 ! for strings
+ call add_directory_to_filename('evo.dat',filename)
 
  if(start/=0)then
-  open(newunit=ievo,file='data/evo.dat',status='old',&
+  open(newunit=ievo,file=filename,status='old',&
        position='append',iostat=ierr)
   if(ierr==0)return ! Return if evofile already exists.
  end if
 
 ! Write headers if it needs to be freshly made.
- open(newunit=ievo,file='data/evo.dat',status='replace')
+ open(newunit=ievo,file=filename,status='replace')
 
  write(ievo,'(a10)',advance='no')'tn'
  write(ievo,forma,advance="no")'time'
@@ -313,7 +314,7 @@ subroutine open_sinkfile
  use mpi_utils, only:myrank
 
  integer:: ierr,n
- character(len=50):: forma, forme, header
+ character(len=70):: forma, forme, header, filename
 
 !-----------------------------------------------------------------------------
 
@@ -322,15 +323,16 @@ subroutine open_sinkfile
 
  write(forma,'("(a",i2,")")')sigfig+8 ! for strings
  write(forme,'("(1x,1PE",i2,".",i2,"e2)")')sigfig+7,sigfig-1 ! for real numbers
+ call add_directory_to_filename('sinks.dat',filename)
 
  if(start/=0)then
-  open(newunit=iskf,file='data/sinks.dat',status='old',&
+  open(newunit=iskf,file=filename,status='old',&
        position='append',iostat=ierr)
   if(ierr==0)return ! Return if sinks file already exists.
  end if
 
 ! Write headers if it needs to be freshly made.
- open(newunit=iskf,file='data/sinks.dat',status='replace')
+ open(newunit=iskf,file=filename,status='replace')
 
  do n = 1, nsink
   write(iskf,'(2x,a,i0,a)',advance="no")"Msink_",n,"/Msun="
@@ -427,8 +429,11 @@ end subroutine write_grid
 subroutine write_grid_bin
  use grid
  integer :: ui
+ character(len=70):: filename
 
- open(newunit=ui,file='data/gridfile.bin',status='replace',form='unformatted')
+ call add_directory_to_filename('gridfile.bin',filename)
+
+ open(newunit=ui,file=filename,status='replace',form='unformatted')
 
  write(ui)x1(gis_global-2:gie_global+2),xi1(gis_global-2:gie_global+2),dx1(gis_global-2:gie_global+2),dxi1(gis_global-2:gie_global+2),&
           x2(gjs_global-2:gje_global+2),xi2(gjs_global-2:gje_global+2),dx2(gjs_global-2:gje_global+2),dxi2(gjs_global-2:gje_global+2),&
@@ -448,10 +453,11 @@ subroutine write_grid_dat
  use io, only: write_string_master, open_file_write_ascii, close_file
 
  character(len=50):: formhead,formval,formnum
- character(len=200) :: str
+ character(len=200) :: str,filename
  integer:: i,j,k,ui
 
- call open_file_write_ascii('data/gridfile.dat',ui)
+ call add_directory_to_filename('gridfile.dat',filename)
+ call open_file_write_ascii(filename,ui)
  call write_string_master(ui, '')
  write(formhead,'("(",i1,"a5,",i1,"a",i2,")")')dim,dim+1,sigfig+8
  write(formval ,'("(",i1,"i5,",i1,"(1x,1PE",i2,".",i2,"e2))")')&
@@ -604,7 +610,8 @@ subroutine write_grid_dat
 
  if(write_other_slice)then
 
-  call open_file_write_ascii('data/othergrid.dat',ui)
+  call add_directory_to_filename('othergrid.dat',filename)
+  call open_file_write_ascii(filename,ui)
   call write_string_master(ui, '')
   write(formhead,'("(",i1,"a5,",i1,"a",i2,")")')2,2+1,sigfig+8
   write(formval ,'("(",i1,"i5,",i1,"(1x,1PE",i2,".",i2,"e2))")')&
@@ -685,7 +692,7 @@ subroutine write_bin
 
  implicit none
 
- character(len=50):: binfile
+ character(len=70):: binfile
  integer :: un
 
 !-----------------------------------------------------------------------------
@@ -1038,6 +1045,7 @@ subroutine write_extgrv
  use io, only:open_file_write,close_file, write_var, write_extgrv_array, write_dummy_recordmarker
  integer :: ui
  real(8) :: mcore
+ character(len=70):: filename
 
  ! get mcore and ensure each task has the same value
  if (is==is_global) then
@@ -1047,7 +1055,8 @@ subroutine write_extgrv
  endif
  call allreduce_mpi('max', mcore)
 
- call open_file_write('data/extgrv.bin', ui)
+ call add_directory_to_filename('extgrv.bin',filename)
+ call open_file_write(filename, ui)
 
  call write_dummy_recordmarker(ui)
  call write_var(ui, mcore)
@@ -1300,25 +1309,47 @@ subroutine set_file_name(prefix,tn,time,filename)
 
  character(len=*),intent(in):: prefix
  character(len=*),intent(out)::filename
+ character(len=50)::filename1
  integer,intent(in):: tn
  real(8),intent(in):: time
 
 !-----------------------------------------------------------------------------
  select case(outstyle)
  case(1)
-  write(filename,'(a5,a,i11.11,a,a4)')&
-   'data/',trim(prefix),nint(time/dt_unit_in_sec),trim(dt_unit),'.dat'
+  write(filename1,'(a,i11.11,a,a4)')&
+   trim(prefix),nint(time/dt_unit_in_sec),trim(dt_unit),'.dat'
   if(time/dt_unit_in_sec>2147483647d0)then ! if integer is overflowed
-   write(filename,'(a5,a,i9.9,"00",a,a4)')&
-    'data/',trim(prefix),nint(time/dt_unit_in_sec*0.01d0),trim(dt_unit),'.dat'
+   write(filename1,'(a,i9.9,"00",a,a4)')&
+    trim(prefix),nint(time/dt_unit_in_sec*0.01d0),trim(dt_unit),'.dat'
   end if
  case(2)
-  write(filename,'(a5,a,i8.8,a4)')'data/',trim(prefix),tn,'.dat'
+  write(filename1,'(a,i8.8,a4)')trim(prefix),tn,'.dat'
  end select
 
-return
+ call add_directory_to_filename(filename1,filename)
+
+ return
 end subroutine set_file_name
 
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+!                    SUBROUTINE ADD_DIRECTORY_TO_FILENAME
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+! PURPOSE: To add the directory to the filename string
+
+subroutine add_directory_to_filename(filename,fullname)
+
+ use settings,only:outdir
+
+ character(len=*),intent(in):: filename
+ character(len=*),intent(out):: fullname
+
+!-----------------------------------------------------------------------------
+
+ write(fullname,'(a,"/",a)') trim(outdir),trim(filename)
+
+return
+end subroutine add_directory_to_filename
 
 !\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 !                          SUBROUTINE GET_HEADER

--- a/src/profiler.f90
+++ b/src/profiler.f90
@@ -50,8 +50,6 @@ contains
 
 subroutine init_profiler
 
- integer::i
-
 !-----------------------------------------------------------------------------
 
  wtime = 0d0
@@ -180,6 +178,7 @@ subroutine start_clock(i)
 
 !-----------------------------------------------------------------------------
 
+ if(i==18) print*,i,routine_name(i),parent(i),clock_on(i)
  if(clock_on(i))then
   print*,"Error in start_clock"
   print*,'category: ',routine_name(i)

--- a/src/profiler.f90
+++ b/src/profiler.f90
@@ -17,14 +17,14 @@ module profiler_mod
   wtint=10,& ! MUSCL interpolation
   wteos=11,& ! equation of state
   wtsmr=12,& ! smearing
-  wtsm2=13,& ! smearing MPI sweep
+  wtsm2=13,& ! MPI sweep for smearing
   wttim=14,& ! time stepping
   wtgrv=15,& ! gravity
   wtgbn=16,& ! gravbound
   wtpoi=17,& ! Poisson solver
   wthyp=18,& ! hyperbolic self-gravity
   wtgsm=19,& ! gravity smearing
-  wtgs2=20,& ! MPI sweep
+  wtgs2=20,& ! MPI sweep gravity smearing
   wtsho=21,& ! shockfind
   wtrad=22,& ! radiation
   wtopc=23,& ! opacity
@@ -70,14 +70,14 @@ subroutine init_profiler
  parent(wtint) = wthyd ! MUSCL interpolation
  parent(wteos) = wthyd ! equation of state
  parent(wtsmr) = wthyd ! smearing
- parent(wtsm2) = wtsmr ! smearing MPI sweep
+ parent(wtsm2) = wtsmr ! MPI sweep for smearing
  parent(wttim) = wtlop ! time stepping
  parent(wtgrv) = wtlop ! gravity
  parent(wtgbn) = wtgrv ! gravbound
  parent(wtpoi) = wtgrv ! Poisson solver
  parent(wthyp) = wtgrv ! hyperbolic self-gravity
  parent(wtgsm) = wtgrv ! gravity smearing
- parent(wtgs2) = wtgsm ! gravity smearing MPI sweep
+ parent(wtgs2) = wtgsm ! MPI sweep gravity smearing
  parent(wtout) = wtlop ! output
  parent(wtsho) = wtlop ! shockfind
  parent(wtrad) = wtlop ! radiation
@@ -102,14 +102,14 @@ subroutine init_profiler
  routine_name(wtint) = 'Interpolate' ! MUSCL interpolation
  routine_name(wteos) = 'EoS'         ! equation of state
  routine_name(wtsmr) = 'Smearing'    ! smearing
- routine_name(wtsm2) = 'MPI sweep'   ! smearing MPI sweep
+ routine_name(wtsm2) = 'MPI sweep'   ! MPI sweep for smearing
  routine_name(wttim) = 'Timestep'    ! time stepping
  routine_name(wtgrv) = 'Gravity'     ! gravity
  routine_name(wtgbn) = 'Gravbound'   ! gravbound
  routine_name(wtpoi) = 'MICCG'       ! Poisson solver
  routine_name(wthyp) = 'Hyperbolic'  ! hyperbolic self-gravity
  routine_name(wtgsm) = 'Grav smear'  ! gravity smearing
- routine_name(wtgs2) = 'MPI sweep'   ! gravity smearing MPI sweep
+ routine_name(wtgs2) = 'MPI sweep'   ! MPI sweep for gravity smearing
  routine_name(wtout) = 'Output'      ! output
  routine_name(wtsho) = 'Shockfind'   ! shockfind
  routine_name(wtrad) = 'Radiation'   ! radiation
@@ -333,12 +333,6 @@ subroutine profiler_output1(ui,wti)
 
  end if
 
-!!$ select case(j)
-!!$ case(0)
-!!$  k = maxlbl
-!!$ case(1:)
-!!$  k = maxlbl + 2 + get_layer(wti)*2
-!!$ end select
  write(form1,'(a,i2,a)')'(a',i,',":",4(1X,F10.3,a))'
  write(ui,form1)adjustl(lbl),wtime_avg(wti),'s',&
                 wtime_avg(wti)/wtime_avg(wtlop)*1d2,'%',&

--- a/src/profiler.f90
+++ b/src/profiler.f90
@@ -2,7 +2,7 @@ module profiler_mod
  implicit none
 
  public:: init_profiler,profiler_output1,start_clock,stop_clock,reset_clock
- integer,parameter:: n_wt=27 ! number of profiling categories
+ integer,parameter:: n_wt=29 ! number of profiling categories
  real(8):: wtime(0:n_wt),wtime_max(0:n_wt),wtime_min(0:n_wt),wtime_avg(0:n_wt),imbalance(0:n_wt)
  integer,parameter:: &
   wtini=1 ,& ! initial conditions
@@ -17,25 +17,28 @@ module profiler_mod
   wtint=10,& ! MUSCL interpolation
   wteos=11,& ! equation of state
   wtsmr=12,& ! smearing
-  wttim=13,& ! time stepping
-  wtgrv=14,& ! gravity
-  wtgbn=15,& ! gravbound
-  wtpoi=16,& ! Poisson solver
-  wthyp=17,& ! hyperbolic self-gravity
-  wtgsm=18,& ! gravity smearing
-  wtsho=19,& ! shockfind
-  wtrad=20,& ! radiation
-  wtopc=21,& ! opacity
-  wtrfl=22,& ! radiative flux
-  wtsnk=23,& ! sink motion
-  wtacc=24,& ! sink accretion
-  wtout=25,& ! output
-  wtmpi=26,& ! mpi exchange
-  wtwai=27,& ! mpi wait
+  wtsm2=13,& ! smearing MPI sweep
+  wttim=14,& ! time stepping
+  wtgrv=15,& ! gravity
+  wtgbn=16,& ! gravbound
+  wtpoi=17,& ! Poisson solver
+  wthyp=18,& ! hyperbolic self-gravity
+  wtgsm=19,& ! gravity smearing
+  wtgs2=20,& ! MPI sweep
+  wtsho=21,& ! shockfind
+  wtrad=22,& ! radiation
+  wtopc=23,& ! opacity
+  wtrfl=24,& ! radiative flux
+  wtsnk=25,& ! sink motion
+  wtacc=26,& ! sink accretion
+  wtout=27,& ! output
+  wtmpi=28,& ! mpi exchange
+  wtwai=29,& ! mpi wait
   wttot=0    ! total
  integer,public:: parent(0:n_wt),maxlbl
  character(len=30),public:: routine_name(0:n_wt)
  logical,public:: clock_on(0:n_wt)
+ real(8),parameter,private:: thres=1d-10
 
 contains
 
@@ -67,12 +70,14 @@ subroutine init_profiler
  parent(wtint) = wthyd ! MUSCL interpolation
  parent(wteos) = wthyd ! equation of state
  parent(wtsmr) = wthyd ! smearing
+ parent(wtsm2) = wtsmr ! smearing MPI sweep
  parent(wttim) = wtlop ! time stepping
  parent(wtgrv) = wtlop ! gravity
  parent(wtgbn) = wtgrv ! gravbound
  parent(wtpoi) = wtgrv ! Poisson solver
  parent(wthyp) = wtgrv ! hyperbolic self-gravity
  parent(wtgsm) = wtgrv ! gravity smearing
+ parent(wtgs2) = wtgsm ! gravity smearing MPI sweep
  parent(wtout) = wtlop ! output
  parent(wtsho) = wtlop ! shockfind
  parent(wtrad) = wtlop ! radiation
@@ -97,12 +102,14 @@ subroutine init_profiler
  routine_name(wtint) = 'Interpolate' ! MUSCL interpolation
  routine_name(wteos) = 'EoS'         ! equation of state
  routine_name(wtsmr) = 'Smearing'    ! smearing
+ routine_name(wtsm2) = 'MPI sweep'   ! smearing MPI sweep
  routine_name(wttim) = 'Timestep'    ! time stepping
  routine_name(wtgrv) = 'Gravity'     ! gravity
  routine_name(wtgbn) = 'Gravbound'   ! gravbound
  routine_name(wtpoi) = 'MICCG'       ! Poisson solver
  routine_name(wthyp) = 'Hyperbolic'  ! hyperbolic self-gravity
  routine_name(wtgsm) = 'Grav smear'  ! gravity smearing
+ routine_name(wtgs2) = 'MPI sweep'   ! gravity smearing MPI sweep
  routine_name(wtout) = 'Output'      ! output
  routine_name(wtsho) = 'Shockfind'   ! shockfind
  routine_name(wtrad) = 'Radiation'   ! radiation
@@ -293,8 +300,7 @@ subroutine profiler_output1(ui,wti)
 
  integer,intent(in):: ui,wti
  character(len=30):: form1,lbl
- integer::j,k,next
- real(8),parameter:: thres=1d-10
+ integer::i,j,k,l
 
 !-----------------------------------------------------------------------------
 
@@ -302,38 +308,38 @@ subroutine profiler_output1(ui,wti)
 
  lbl = trim(routine_name(wti))
  j = get_layer(wti)
+ i = maxlbl
  if(j>0)then
 
-! Find the next category with the same parent and finite wall time
-  next = n_wt+1
-  if(wti<n_wt)then
-   do k = wti+1, n_wt
-    if(parent(k)==parent(wti).and.wtime_max(k)>thres)then
-     next = k
-     exit
+  i = i + 4
+  if(last_in_category(wti))then
+   lbl = "└─"//trim(lbl)
+  else
+   lbl = "├─"//trim(lbl)
+  end if
+
+  if(j>1)then
+   l = wti
+   do k = j, 2, -1
+    l = parent(l)
+    if(last_in_category(l))then
+     lbl = "  "//trim(lbl)
+    else
+     lbl = "│ "//trim(lbl)
+     i = i+2
     end if
    end do
   end if
 
-  if(next/=n_wt+1)then
-   lbl = "├─"//trim(lbl)
-  else
-   lbl = "└─"//trim(lbl)
-  end if
-  if(j>1)then
-   do k = j, 2, -1
-    lbl = "│ "//trim(lbl)
-   end do
-  end if
  end if
 
- select case(get_layer(wti))
- case(0)
-  k = maxlbl
- case(1:)
-  k = maxlbl + 2 + get_layer(wti)*2
- end select
- write(form1,'(a,i2,a)')'(a',k,',":",4(1X,F10.3,a))'
+!!$ select case(j)
+!!$ case(0)
+!!$  k = maxlbl
+!!$ case(1:)
+!!$  k = maxlbl + 2 + get_layer(wti)*2
+!!$ end select
+ write(form1,'(a,i2,a)')'(a',i,',":",4(1X,F10.3,a))'
  write(ui,form1)adjustl(lbl),wtime_avg(wti),'s',&
                 wtime_avg(wti)/wtime_avg(wtlop)*1d2,'%',&
                 wtime_avg(wti)/wtime_avg(wttot)*1d2,'%',&
@@ -342,6 +348,28 @@ subroutine profiler_output1(ui,wti)
 return
 end subroutine profiler_output1
 
+function last_in_category(wti)
+ integer,intent(in):: wti
+ logical:: last_in_category
+ integer:: k, next
 
+! Find the next category with the same parent and finite wall time
+ next = n_wt+1
+ if(wti<n_wt)then
+  do k = wti+1, n_wt
+   if(parent(k)==parent(wti).and.wtime_max(k)>thres)then
+    next = k
+    exit
+   end if
+  end do
+ end if
+
+ if(next==n_wt+1)then
+  last_in_category = .true.
+ else
+  last_in_category = .false.
+ end if
+
+end function last_in_category
 
 end module profiler_mod

--- a/src/profiler.f90
+++ b/src/profiler.f90
@@ -76,7 +76,7 @@ subroutine init_profiler
  parent(wtgbn) = wtgrv ! gravbound
  parent(wtpoi) = wtgrv ! Poisson solver
  parent(wthyp) = wtgrv ! hyperbolic self-gravity
- parent(wtgsm) = wtgrv ! gravity smearing
+ parent(wtgsm) = wthyp ! gravity smearing
  parent(wtgs2) = wtgsm ! MPI sweep gravity smearing
  parent(wtout) = wtlop ! output
  parent(wtsho) = wtlop ! shockfind
@@ -121,15 +121,32 @@ subroutine init_profiler
  routine_name(wtwai) = 'MPI wait'    ! MPI wait
  routine_name(wttot) = 'Total'       ! total
 
- do i = 0, n_wt
-  maxlbl = max(maxlbl,len_trim(routine_name(i))+get_layer(i)*2)
- end do
- maxlbl = maxlbl + 1
-
  clock_on(0:n_wt) = .false.
 
  return
 end subroutine init_profiler
+
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+!                         SUBROUTINE GET_MAXLBL
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+! PURPOSE: To compute maximum number of characters in the label
+
+subroutine get_maxlbl
+
+ integer:: i
+
+!-----------------------------------------------------------------------------
+
+ maxlbl = 0
+ do i = 0, n_wt
+  if(wtime_max(i)>thres) &
+   maxlbl = max(maxlbl,len_trim(routine_name(i))+get_layer(i)*2)
+ end do
+ maxlbl = maxlbl + 1
+
+return
+end subroutine get_maxlbl
 
 ! Get layer number \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 function get_layer(i) result(ilayer)
@@ -343,6 +360,7 @@ return
 end subroutine profiler_output1
 
 function last_in_category(wti)
+! Function to judge whether a profiler element is the last element in a subcategory.
  integer,intent(in):: wti
  logical:: last_in_category
  integer:: k, next

--- a/src/setup.f90
+++ b/src/setup.f90
@@ -168,9 +168,11 @@ subroutine read_parameters(filename)
                     is, ie, js, je, ks, ke, imesh, jmesh, kmesh, &
                     x1min, x2min, x3min, &
                     fmr_max, fmr_lvl
- namelist /out_con/ outstyle, endstyle, tnlim, t_end, dt_out, tn_out, tn_evo,&
-                    dt_unit, sigfig, outres, write_other_vel, write_shock, &
-                    write_evo, write_other_slice, write_temp, write_mc
+ namelist /out_con/ outdir, outstyle, endstyle, &
+                    tnlim, t_end, dt_out, tn_out, tn_evo, dt_unit, &
+                    sigfig, outres, output_ascii, write_other_vel, &
+                    write_shock, write_evo, write_other_slice, write_temp, &
+                    write_mc
  namelist /eos_con/ eostype, gamma, eoserr, compswitch, muconst, spn
  namelist /simucon/ crdnt, courant, rktype, mag_on, flux_limiter, alpha9wave,&
                     include_cooling, include_extforce, frame, extrasfile

--- a/src/smear.f90
+++ b/src/smear.f90
@@ -92,7 +92,7 @@ contains
   use mpi_utils,only:allreduce_mpi
 
   character(len=*),intent(in):: which
-  integer:: i,j,k,n,jb,kb,wtind
+  integer:: i,j,k,n,jb,kb,wtind,wtin2
   integer,allocatable:: smeared(:)
 
 !-----------------------------------------------------------------------------
@@ -104,9 +104,9 @@ contains
 
   select case(which)
   case('hydro')
-   wtind = wtsmr
+   wtind = wtsmr ; wtin2 = wtsm2
   case('grav')
-   wtind = wtgsm
+   wtind = wtgsm ; wtin2 = wtgs2
   end select
 
   call start_clock(wtind)
@@ -144,6 +144,7 @@ contains
 
 ! Second sweep (for effective cells that span over multiple MPI ranks)
    if(minval(smeared)==0)then
+    call start_clock(wtin2)
     do n = 1, fmr_max
      if(fmr_lvl(n)==0)cycle
      jb = block_j(n)
@@ -163,6 +164,7 @@ contains
       end do
      end do
     end do
+    call stop_clock(wtin2)
    end if
 
    deallocate(smeared)

--- a/work/Makefile
+++ b/work/Makefile
@@ -35,8 +35,10 @@ BIN_DIR = $(HORMONE_DIR)/bin
 
 TARGET = hormone
 
+TARGETA = ascii_output
+
 # compile modules that are being depended on first
-MOD = mpi_utils.F90 modules.f90  profiler.f90 mpi_domain.F90 io.F90 utils.f90 conserve.f90 ionization.f90 eos.f90 miccg.f90 fluxlimiter.f90 hlldflux.f90 dirichlet.f90 particles.f90 radiation.f90 cooling.f90 sinks.f90 composition.f90 star.f90 shockfind.f90  output.f90 smear.f90 input.f90 setup.f90 readbin.f90 tests.f90 restart.f90 fluxboundary.f90 rungekutta.f90 timestep.f90 gridset.f90 gravbound.f90 gravity_hyperbolic.f90 gravity_miccg.f90
+MOD = mpi_utils.F90 modules.f90 profiler.f90 mpi_domain.F90 io.F90 utils.f90 conserve.f90 ionization.f90 eos.f90 miccg.f90 fluxlimiter.f90 hlldflux.f90 dirichlet.f90 particles.f90 radiation.f90 cooling.f90 sinks.f90 composition.f90 star.f90 shockfind.f90 output.f90 smear.f90 input.f90 setup.f90 readbin.f90 tests.f90 restart.f90 fluxboundary.f90 rungekutta.f90 timestep.f90 gridset.f90 gravbound.f90 gravity_hyperbolic.f90 gravity_miccg.f90
 
 # Initial condition routines should be compiled before initialcondition.f90
 INI = eostest.f90 shocktube.f90 orszagtang.f90 sedov.f90 eruption.f90 KHtests.f90 star_init.f90 rsg.f90 polytrope.f90 agndisk.f90 windtunnel.f90 rad_box.f90 stellarcollision.f90 sn2022jli.f90 modify.f90 smearingtest.f90 iotest.f90
@@ -44,12 +46,22 @@ INI = eostest.f90 shocktube.f90 orszagtang.f90 sedov.f90 eruption.f90 KHtests.f9
 MODF= $(patsubst %,$(SRC_DIR)/%,$(MOD))
 INIF= $(patsubst %,$(SRC_DIR)/%,$(INI))
 TARGETF= $(patsubst %,$(SRC_DIR)/%.f90,$(TARGET))
+TARGETAF= $(patsubst %,$(SRC_DIR)/%.f90,$(TARGETA))
 SRC = $(MODF) $(INIF) \
-      $(filter-out $(MODF) $(INIF) $(TARGETF), $(sort $(wildcard $(SRC_DIR)/*.f90 $(SRC_DIR)/*.F90))) \
+      $(filter-out $(MODF) $(INIF) $(TARGETF) $(TARGETAF), $(sort $(wildcard $(SRC_DIR)/*.f90 $(SRC_DIR)/*.F90))) \
       $(TARGETF)
 _OBJ = $(patsubst $(SRC_DIR)/%.f90,%.o,$(SRC))
 OBJ = $(patsubst $(SRC_DIR)/%.F90,%.o,$(_OBJ))
 OBJ_F = $(patsubst %.o,$(OBJ_DIR)/%.o,$(OBJ))
+
+ASCIIF= $(patsubst %,$(SRC_DIR)/%.f90,$(ASCII))
+SRCA = $(MODF) $(INIF) \
+      $(filter-out $(MODF) $(INIF) $(TARGETF) $(TARGETAF), $(sort $(wildcard $(SRC_DIR)/*.f90 $(SRC_DIR)/*.F90))) \
+      $(TARGETAF)
+MODAF= $(patsubst %,$(SRC_DIR)/%,$(MODA))
+_OBJA = $(patsubst $(SRC_DIR)/%.f90,%.o,$(SRCA))
+OBJA = $(patsubst $(SRC_DIR)/%.F90,%.o,$(_OBJA))
+OBJA_F = $(patsubst %.o,$(OBJ_DIR)/%.o,$(OBJA))
 
 all: $(TARGET)
 
@@ -59,8 +71,13 @@ debug: $(TARGET)
 profile: FCFLAG+=$(PRFLAG)
 profile: $(TARGET)
 
+ascii: $(TARGETA)
+
 $(TARGET): $(OBJ_F)
 	$(FC) $(FCFLAG) -o $@ $(OBJ_F)
+
+$(TARGETA): $(OBJA_F)
+	$(FC) $(FCFLAG) -o $@ $(OBJA_F)
 
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.F90
 	$(FC) $(FPPFLAG) $(FCFLAG) -c $< -o $@ $(MODFLAG)$(OBJ_DIR)
@@ -70,4 +87,4 @@ $(OBJ_DIR)/%.o: $(SRC_DIR)/%.f90
 
 .PHONY: clean
 clean:
-	rm -f *~ $(SRC_DIR)/*~ hormone $(OBJ_DIR)/*
+	rm -f *~ $(SRC_DIR)/*~ $(TARGET) $(TARGETA) $(OBJ_DIR)/*


### PR DESCRIPTION
In some machines like OzStar, the ascii output is extremely slow. Sometimes it is unbearably slow that it dominates the computing time.

In this PR, I convert the ascii output into a runtime option, and make a new mode that simply reads in binfile's and outputs pltfile's.
This new mode can be executed by 
```
$ make ascii
```
and then run `./ascii_output`.
At least on OzStar, this is most efficient when run without MPI.

Other small changes were introduced too.

- Made a new option to choose the name of the output directory. Defaulted to "data".
- Default choice for `output_ascii` set to `.false.` for the `sn2022jli` simtype, as it was unbearably slow on OzStar.
- Added extra profiler output for the MPI sweeps in `smear`
- Fixed a bug in `profiler_output1`