### PR TITLE
Quick bug fixes

### DIFF
--- a/src/ascii_output.f90
+++ b/src/ascii_output.f90
@@ -70,8 +70,8 @@ program write_ascii
 ! Start initial setup
   call allocations
 
-  outtn = 0
-  outtime = 0d0
+  outtn = start
+  outtime = dble(start)*dt_unit_in_sec
   do
    call set_file_name('bin',outtn,outtime,file)
    print*,'Reading ',file

--- a/src/smear.f90
+++ b/src/smear.f90
@@ -149,7 +149,6 @@ contains
     do n = 1, nsmear
      if(smeared(n)==0)then
       l = lijk_from_id(0,n)
-      if(fmr_lvl(l)==0)cycle
       i = lijk_from_id(1,n)
       j = lijk_from_id(2,n)
       k = lijk_from_id(3,n)
@@ -324,27 +323,25 @@ contains
 ! First smear chemical elements
   if(compswitch>=2)then
    allocate(spctot(1:spn))
-!$omp parallel
    do n = 1, spn
     arr_sum = 0d0
     if(overlap)then
-!$omp do private(j,k) collapse(2) reduction(+:arr_sum)
+!$omp parallel do private(j,k) collapse(2) reduction(+:arr_sum)
      do k = kl, kr
       do j = jl, jr
        arr_sum = arr_sum + u(i,j,k,icnt)*dvol(i,j,k)*spc(n,i,j,k)
       end do
      end do
-!$omp end do
+!$omp end parallel do
     end if
     spctot(n) = arr_sum
    end do
-!$omp end parallel
   end if
   call allreduce_mpi('sum',spctot)
   if(compswitch>=2.and.overlap)then
 !$omp parallel do private(n)
    do n = 1, spn
-    spc(n,i,jl:jr,kl:kr) = spctot(n) / mtot    
+    spc(n,i,jl:jr,kl:kr) = spctot(n) / mtot
    end do
 !$omp end parallel do
   end if

--- a/work/Makefile
+++ b/work/Makefile
@@ -20,7 +20,8 @@ endif
 
 ifeq (${FC},ifx)
 ifeq (${MPI},yes)
-$(error "MPI not supported for ifx")
+override FC := mpiifx
+FPPFLAG += -DMPI
 endif
 MODFLAG= -module # trailing space is important
 FCFLAG:= $(CFLAG) -qopenmp -fp-model precise #-heap-arrays

--- a/work/hokusai.sh
+++ b/work/hokusai.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+#SBATCH --job-name=test_mpi
+#SBATCH --partition=mpc
+#SBATCH --account=RB240033
+#SBATCH --nodes=16
+#SBATCH --ntasks-per-node=4
+#SBATCH --cpus-per-task=16
+#SBATCH --time=24:00:00
+#SBATCH --mem=5G
+module load intel
+export OMP_STACKSIZE=512M
+export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK}
+export OMP_PLACES=cores
+export OMP_PROC_BIND=close
+srun --cpus-per-task=${SLURM_CPUS_PER_TASK} ./hormone


### PR DESCRIPTION
A quick bug fix to `angular_smear_global` to make it OpenMP safe.

Also enabled the `mpiifx` option for the Makefile as the HOKUSAI supercomputer only has Intel MPI and no modules for gfortran+OpenMPI.