### PR TITLE
Change smear to a 3-step process

### DIFF
--- a/src/mpi_utils.F90
+++ b/src/mpi_utils.F90
@@ -7,6 +7,7 @@ module mpi_utils
   interface allreduce_mpi
     module procedure allreduce_mpi_real8
     module procedure allreduce_mpi_real8_array
+    module procedure allreduce_mpi_real8_2darray
     module procedure allreduce_mpi_int4
     module procedure allreduce_mpi_int4_array
   end interface allreduce_mpi
@@ -107,6 +108,43 @@ module mpi_utils
 
   end subroutine allreduce_mpi_real8_array
 
+  subroutine allreduce_mpi_real8_2darray(op_str, value)
+    character(len=*), intent(in) :: op_str
+    real(8), intent(inout) :: value(:,:)
+
+#ifdef MPI
+    real(8), allocatable :: value_reduced(:,:)
+    integer :: op, ierr
+
+    allocate(value_reduced,mold=value)
+
+    select case (op_str)
+    case ('sum')
+      op = MPI_SUM
+    case ('max')
+      op = MPI_MAX
+    case ('min')
+      op = MPI_MIN
+    case default
+      error stop "Invalid operation specified"
+    end select
+
+    call MPI_ALLREDUCE(value, value_reduced, size(value), MPI_REAL8, op, MPI_COMM_WORLD, ierr)
+    value = value_reduced
+
+    deallocate(value_reduced)
+#else
+    ! Check if operation is valid, but do nothing
+    select case (op_str)
+    case ('sum', 'max', 'min')
+      value = value
+    case default
+      error stop "Invalid operation specified"
+    end select
+#endif
+
+  end subroutine allreduce_mpi_real8_2darray
+  
   subroutine allreduce_mpi_int4(op_str, value)
     character(len=*), intent(in) :: op_str
     integer, intent(inout) :: value

--- a/src/smear.f90
+++ b/src/smear.f90
@@ -2,8 +2,12 @@ module smear_mod
  implicit none
 
  public:: smear_setup,smear
+ private:: angular_sums_hydro,angular_sums_grav,&
+           angular_smear_hydro,angular_smear_grav,angular_smear_e,&
+           get_compensation,get_id
 
- integer,public:: nsmear, nsmear_mydom, nsmear_split
+ integer,public:: nsmear
+ integer,private:: nsmear_mydom, nsmear_split
  integer,allocatable,public:: block_j(:),block_k(:),lijk_from_id(:,:)
  integer,allocatable,private:: list_split(:),list_mydom(:,:)
  real(8),allocatable,private:: dvol_block(:)
@@ -366,8 +370,6 @@ contains
   use utils,only:get_vpol
   use gravmod,only:totphi,gravswitch
 
-  implicit none
-
   integer,intent(in)::i,js_,je_,ks_,ke_
   real(8),intent(in):: mtot,momtot(1:3),spctot(1:max(spn,1))
   real(8),intent(inout):: etot
@@ -419,8 +421,6 @@ contains
   use physval,only:u,spc,icnt,iene,imo1,imo2,imo3
   use utils
   use gravmod,only:totphi,gravswitch
-
-  implicit none
 
   integer,intent(in)::i,js_,je_,ks_,ke_
   real(8),intent(out):: mtot,momtot(1:3),etot
@@ -475,8 +475,6 @@ contains
   use grid,only:dvol,js,je,ks,ke
   use gravmod,only:grvphi,grvpsi
 
-  implicit none
-
   integer,intent(in)::i,js_,je_,ks_,ke_
   real(8),intent(out):: phitot,psitot
   integer:: jl,jr,kl,kr
@@ -503,8 +501,6 @@ contains
 
   use grid,only:js,je,ks,ke
   use gravmod,only:grvphi,grvpsi
-
-  implicit none
 
   integer,intent(in)::i,js_,je_,ks_,ke_
   real(8),intent(in):: phitot,psitot


### PR DESCRIPTION
This PR drastically changes `smear` so that it only does one or two MPI reduction calls.

I added two lists of effective cells to keep track of things.
`list_split`: List of effective cell IDs that are split over multiple MPI ranks.
`list_mydom(1,:)`: List of effective cell IDs that are partially covered by the domain. 
`list_mydom(2,:)`: ID within `list_split` if it is split over multiple MPI ranks. Set to 0 when it is not on `list_split`.

1. The first step sums up the conserved quantities (mass, momentum, energy, etc) over the effective cells. If only part of the effective cell is covered by the domain, the sum will only be a fraction of the total sum.
2. The second step reduces the summed up quantities over all MPI ranks.
3. The third step updates the local quantities by values averaged over the effective cell.
4. (For `which=='hydro'` only) Energy requires some amendments due to the change in density distribution, so is reduced and smeared at an additional step.