### PR TITLE
Debug Ebind calculation in eruption

### DIFF
--- a/src/init/eruption.f90
+++ b/src/init/eruption.f90
@@ -92,7 +92,7 @@ subroutine eruption
   case default
    ene = eos_e(rho(i),pres(i),Temp,imu_local)
   end select
-  Ebind = Ebind - G*m(i-1)*(m(i)-m(i-1)) / r(i-1) + ene*(m(i)-m(i-1))
+  Ebind = Ebind - G*m(i-1)*(m(i)-m(i-1)) / r(i-1) + ene/rho(i)*(m(i)-m(i-1))
  end do
 
 ! Set explosion energy to fraction of binding energy


### PR DESCRIPTION
Eva, Rafe and Stan spotted an error in the Ebind calculation inside the `eruption` module.
It turned out that the internal energy was computed as energy density, whereas it should be computed as specific energy.

Simple fix made it consistent with Owocki+2019.