### PR TITLE
Fix evo_output

### DIFF
--- a/src/init/sn2022jli.f90
+++ b/src/init/sn2022jli.f90
@@ -258,28 +258,29 @@ subroutine sn2022jli
 
 ! Find the right entropy normalization through the bisection method
  do
-
   Ebind = 0d0
 !$omp parallel do private(i,j,k,entr,TT) collapse(3) reduction(+:Ebind)
   do k = ks, ke
    do j = js, je
     do i = is, ie
-     if(x1(i)<=radius)then
+     if(mc(i)>mass)cycle
 
-      entr = entropy_from_dT(d(i,j,k),T(i,j,k),imu(i,j,k),spc(1,i,j,k),spc(2,i,j,k))
+     entr = entropy_from_dT(d(i,j,k),T(i,j,k),imu(i,j,k),&
+                            spc(1,i,j,k),spc(2,i,j,k))
 
-      entr = entr + entr0*min(1d0,mheat/((mass-mc(i))+tiny))
-      eint(i,j,k) = get_e_from_ds(d(i,j,k),entr,imu(i,j,k),spc(1,i,j,k),spc(2,i,j,k))
-      TT = T(i,j,k)
-      select case(eostype)
-      case(0,1)
-       p(i,j,k) = eos_p(d(i,j,k),eint(i,j,k),TT,imu(i,j,k))
-      case(2)
-       p(i,j,k) = eos_p(d(i,j,k),eint(i,j,k),TT,imu(i,j,k),&
+     entr = entr + entr0*min(1d0,mheat/((mass-mc(i))+tiny))
+     eint(i,j,k) = get_e_from_ds(d(i,j,k),entr,imu(i,j,k),&
+                                 spc(1,i,j,k),spc(2,i,j,k))
+     TT = T(i,j,k)
+     select case(eostype)
+     case(0,1)
+      p(i,j,k) = eos_p(d(i,j,k),eint(i,j,k),TT,imu(i,j,k))
+     case(2)
+      p(i,j,k) = eos_p(d(i,j,k),eint(i,j,k),TT,imu(i,j,k),&
                        spc(1,i,j,k),spc(2,i,j,k))
-      end select
-      Ebind = Ebind + (eint(i,j,k)+0.5d0*d(i,j,k)*grvphi(i,j,k))*dvol(i,j,k)*fac
-     end if
+     end select
+     Ebind = Ebind + (eint(i,j,k)+0.5d0*d(i,j,k)*grvphi(i,j,k))*dvol(i,j,k)*fac
+
     end do
    end do
   end do

--- a/src/main/output.f90
+++ b/src/main/output.f90
@@ -187,54 +187,31 @@ subroutine evo_output
   if(eq_sym) Ebtot = 2d0*Ebtot
  end if
  if(gravswitch>=1)then
-  if(include_extgrv)then
 ! grvphi is self-gravity so is double counted, whereas extgrv is not
-   Egtot = sum(d(is:ie,js:je,ks:ke) &
-              *(0.5d0*grvphi(is:ie,js:je,ks:ke)+extgrv(is:ie,js:je,ks:ke)) &
+  Egtot = sum(d(is:ie,js:je,ks:ke) &
+              *(totphi(is:ie,js:je,ks:ke)-0.5d0*grvphi(is:ie,js:je,ks:ke)) &
               *dvol(is:ie,js:je,ks:ke))
-   if (is==is_global) Mtot = Mtot + mc(is-1)
+  if (is==is_global) Mtot = Mtot + mc(is-1)
 
-   Mbound=0d0;Ebound=0d0;Jbound=0d0
-   do k = ks, ke
-    do j = js, je
-     do i = is, ie
-      if(grvphi(i,j,k)+extgrv(i,j,k)+(e(i,j,k)-eint(i,j,k))/d(i,j,k)<=0d0)then
-       Mbound = Mbound + d(i,j,k)*dvol(i,j,k)
-       Ebound = Ebound + (e(i,j,k)+d(i,j,k)*(0.5d0*grvphi(i,j,k)+extgrv(i,j,k))) &
-                         *dvol(i,j,k)
-       select case(crdnt)
-       case(1)
-        Jbound = Jbound + d(i,j,k)*x1(i)*v2(i,j,k)*dvol(i,j,k)
-       case(2)
-        Jbound = Jbound + d(i,j,k)*x1(i)*sinc(j)*v3(i,j,k)*dvol(i,j,k)
-       end select
-      end if
-     end do
+  Mbound=0d0;Ebound=0d0;Jbound=0d0
+  do k = ks, ke
+   do j = js, je
+    do i = is, ie
+     if(totphi(i,j,k)+(e(i,j,k)-eint(i,j,k))/d(i,j,k)<=0d0)then
+      Mbound = Mbound + d(i,j,k)*dvol(i,j,k)
+      Ebound = Ebound + (e(i,j,k)+d(i,j,k)*(totphi(i,j,k)-0.5d0*grvphi(i,j,k)))&
+                        *dvol(i,j,k)
+      select case(crdnt)
+      case(1)
+       Jbound = Jbound + d(i,j,k)*x1(i)*v2(i,j,k)*dvol(i,j,k)
+      case(2)
+       Jbound = Jbound + d(i,j,k)*x1(i)*sinc(j)*v3(i,j,k)*dvol(i,j,k)
+      end select
+     end if
     end do
    end do
-  else
-   Egtot = 0.5d0*sum(d(is:ie,js:je,ks:ke)*grvphi(is:ie,js:je,ks:ke) &
-                    *dvol(is:ie,js:je,ks:ke))
+  end do
 
-   Mbound=0d0;Ebound=0d0
-   do k = ks, ke
-    do j = js, je
-     do i = is, ie
-      if(grvphi(i,j,k)+(e(i,j,k)-eint(i,j,k))/d(i,j,k)<=0d0)then
-       Mbound = Mbound + d(i,j,k)*dvol(i,j,k)
-       Ebound = Ebound + (e(i,j,k)+d(i,j,k)*0.5d0*grvphi(i,j,k)) &
-                         *dvol(i,j,k)
-       select case(crdnt)
-       case(1)
-        Jbound = Jbound + d(i,j,k)*x1(i)*v2(i,j,k)*dvol(i,j,k)
-       case(2)
-        Jbound = Jbound + d(i,j,k)*x1(i)*sinc(j)*v3(i,j,k)*dvol(i,j,k)
-       end select
-      end if
-     end do
-    end do
-   end do
-  end if
   if(eq_sym)then
    Egtot  = 2d0*Egtot
    Mbound = 2d0*Mbound

--- a/src/main/source.f90
+++ b/src/main/source.f90
@@ -5,7 +5,7 @@ contains
 
 !\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 !
-!                             SUBROUTINE SOURCE
+!                           SUBROUTINE SOURCE
 !
 !\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
@@ -14,12 +14,11 @@ contains
 subroutine source
 
  use grid
- use settings,only:eq_sym,include_extforce,mag_on,radswitch,include_sinks
+ use settings,only:eq_sym,include_extforce,mag_on,radswitch
  use physval
  use constants
  use utils,only:masscoordinate
  use gravmod
- use sink_mod,only:sinkfield
  use radiation_mod,only:radiative_force
  use externalforce_mod
  use profiler_mod
@@ -45,19 +44,7 @@ subroutine source
 
  elseif(gravswitch==2.or.gravswitch==3)then
 
-!$omp parallel do private(i,j,k) collapse(3)
-  do k = ks-1, ke+1
-   do j = js-1, je+1
-    do i = is-1, ie+1
-     totphi(i,j,k) = grvphi(i,j,k)
-    end do
-   end do
-  end do
-!$omp end parallel do
-
-  if(include_extgrv)call externalfield
-  if(include_sinks) call sinkfield
-
+  call get_totphi
   call get_fieldforce(totphi,d,grv1,grv2,grv3)
 
   if(eq_sym.and.crdnt==1)grv3(is:ie,js:je,ks) = 0d0
@@ -260,5 +247,41 @@ subroutine phidamp
 
 return
 end subroutine phidamp
+
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+!
+!                        SUBROUTINE GET_TOTPHI
+!
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+! PURPOSE: To compute total gravitational potential
+
+subroutine get_totphi
+
+ use settings,only:include_sinks,include_extgrv
+ use grid,only:is,ie,js,je,ks,ke
+ use gravmod,only:totphi,grvphi
+ use externalforce_mod,only:externalfield
+ use sink_mod,only:sinkfield
+
+ integer:: i,j,k
+
+!-----------------------------------------------------------------------------
+
+!$omp parallel do private(i,j,k) collapse(3)
+  do k = ks-1, ke+1
+   do j = js-1, je+1
+    do i = is-1, ie+1
+     totphi(i,j,k) = grvphi(i,j,k)
+    end do
+   end do
+  end do
+!$omp end parallel do
+
+  if(include_extgrv)call externalfield
+  if(include_sinks) call sinkfield
+
+return
+end subroutine get_totphi
 
 end module source_mod

--- a/src/post/ascii_output.f90
+++ b/src/post/ascii_output.f90
@@ -30,6 +30,7 @@ program write_ascii
   use readbin_mod
   use output_mod
   use gridset_mod
+  use source_mod
   use profiler_mod
 
   implicit none
@@ -81,6 +82,9 @@ program write_ascii
    call set_file_name('bin',outtn,outtime,file)
    print*,'Reading ',file
    call readbin(file)
+   call set_file_name('plt',outtn,outtime,file)
+   if(gravswitch>=2)call get_totphi
+   print*,'Writing ',file
    call write_plt
    outtime = outtime + dt_out
    outtn = outtn + tn_out

--- a/work/Makefile
+++ b/work/Makefile
@@ -54,7 +54,7 @@ TARGETA = ascii_output
 TARGETL = lightcurve
 
 # compile modules that are being depended on first
-MOD = mpi_utils.F90 modules.f90 profiler.f90 mpi_domain.F90 io.F90 utils.f90 conserve.f90 ionization.f90 eos.f90 miccg.f90 fluxlimiter.f90 hlldflux.f90 dirichlet.f90 particles.f90 opacity.f90 radiation_utils.f90 radiation.f90 cooling.f90 sinks.f90 composition.f90 star.f90 shockfind.f90 output.f90 smear.f90 input.f90 setup.f90 readbin.f90  restart.f90 fluxboundary.f90 rungekutta.f90 timestep.f90 tests.f90 gridset.f90 gravbound.f90 gravity_hyperbolic.f90 gravity_miccg.f90 interpolation.f90 numflux.f90 externalforce.f90 source.f90 
+MOD = mpi_utils.F90 modules.f90 profiler.f90 mpi_domain.F90 io.F90 utils.f90 conserve.f90 ionization.f90 eos.f90 miccg.f90 fluxlimiter.f90 hlldflux.f90 dirichlet.f90 particles.f90 opacity.f90 radiation_utils.f90 radiation.f90 cooling.f90 sinks.f90 externalforce.f90 composition.f90 star.f90 shockfind.f90 output.f90 smear.f90 input.f90 setup.f90 readbin.f90  restart.f90 fluxboundary.f90 rungekutta.f90 timestep.f90 tests.f90 gridset.f90 gravbound.f90 gravity_hyperbolic.f90 gravity_miccg.f90 interpolation.f90 numflux.f90 source.f90
 MODF= $(patsubst %,$(SRC_DIR)/%,$(MOD))
 
 # Initial condition routines should be compiled before initialcondition.f90


### PR DESCRIPTION
`evo_output` outputs the global quantities like total energy, total mass, total bound mass, etc.
This has not been updated since the sink particles were introduced.
I have now changed the definition of `bound_mass` to be the mass where the total energy is negative, including the gravitational potential to the sinks.

I also fixed a minor bug in the `sn2022jli` initial condition.