### PR TITLE
Python reader

### DIFF
--- a/work/data/plot.py
+++ b/work/data/plot.py
@@ -1,0 +1,13 @@
+import horpy as hp
+
+hp.readbin_python.setup_python('../')
+hp.readbin_python.read_gridfile('gridfile.bin')
+hp.readbin_python.read_binfile('bin00000000000ms.dat')
+
+darray =hp.readbin_python.d.copy()
+parray =hp.readbin_python.p.copy()
+x1array=hp.readbin_python.x1.copy()
+x2array=hp.readbin_python.x2.copy()
+x3array=hp.readbin_python.x3.copy()
+print(darray)
+#exec(open('plot.py').read())

--- a/work/scripts/horpy.sh
+++ b/work/scripts/horpy.sh
@@ -1,0 +1,5 @@
+python -m numpy.f2py -h horpy.pyf -m horpy horpy.f90
+cd ../../src/main
+python -m numpy.f2py -c ../../work/scripts/horpy.pyf -m horpy --fcompiler=gfortran --f90flags='-fopenmp' -lgomp mpi_utils.F90 modules.f90 profiler.f90 mpi_domain.F90 io.F90 utils.f90 conserve.f90 ionization.f90 eos.f90 matrix_vars.F90 opacity.f90 radiation_utils.f90 matrix_coeffs.f90 matrix_utils.f90 miccg.f90 fluxlimiter.f90 hlldflux.f90 dirichlet.f90 particles.f90 petsc_solver.F90 matrix_solver.F90 radiation.f90 cooling.f90 sinks.f90 externalforce.f90 composition.f90 star.f90 shockfind.f90 output.f90 smear.f90 input.f90 setup.f90 readbin.f90 timestep.f90 tests.f90 checksetup.f90 ../../work/scripts/horpy.f90
+
+mv horpy* ../../work/

--- a/work/scripts/horpy.sh
+++ b/work/scripts/horpy.sh
@@ -2,4 +2,4 @@ python -m numpy.f2py -h horpy.pyf -m horpy horpy.f90
 cd ../../src/main
 python -m numpy.f2py -c ../../work/scripts/horpy.pyf -m horpy --fcompiler=gfortran --f90flags='-fopenmp' -lgomp mpi_utils.F90 modules.f90 profiler.f90 mpi_domain.F90 io.F90 utils.f90 conserve.f90 ionization.f90 eos.f90 matrix_vars.F90 opacity.f90 radiation_utils.f90 matrix_coeffs.f90 matrix_utils.f90 miccg.f90 fluxlimiter.f90 hlldflux.f90 dirichlet.f90 particles.f90 petsc_solver.F90 matrix_solver.F90 radiation.f90 cooling.f90 sinks.f90 externalforce.f90 composition.f90 star.f90 shockfind.f90 output.f90 smear.f90 input.f90 setup.f90 readbin.f90 timestep.f90 tests.f90 checksetup.f90 ../../work/scripts/horpy.f90
 
-mv horpy* ../../work/
+mv horpy*so ../../work/horpy.so


### PR DESCRIPTION
Adds a very primitive functionality for loading HORMONE binary files into python variables.

To use it, first do 
`$ sh horpy.sh`
in the `work/scripts` directory.
This generates a file called `horpy.so` in the `work` directory. Take that to wherever your python script is.

I placed an example python script `plot.py` in the `work/data` directory.
```
import horpy as hp
hp.readbin_python.setup_python('../')
```
`setup_python(<work directory>)` needs to be called first to allocate the variables inside HORMONE.
Then you can call the read routines by something like
```
hp.readbin_python.readgrid('gridfile.bin')
hp.readbin_python.readbin('bin00000000000s.dat')
```
This will read the files into the variables inside HORMONE.
To copy it to python variables, you need to do something like
```
x1array=hp.readbin_python.x1.copy()
darray=hp.readbin_python.d.copy()
```

Hopefully this is useful for Python users!