### PR TITLE
Echo start number on ./setup continue

### DIFF
--- a/work/scripts/setup
+++ b/work/scripts/setup
@@ -112,11 +112,9 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
 
     if [ "$MODE" = "continue" ]; then
         STARTNUM=$(latest_dump_number)
-	echo "Start=$STARTNUM"
         update_startfile "continue" "" "$STARTNUM"
     else
         STARTNUM=0
-	echo "Start=$STARTNUM"
         # Append " test" if requested
         SIMTYPE_TO_WRITE="$MODE"
         if [ "$TESTFLAG" = "test" ]; then
@@ -132,4 +130,5 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
             cp "$PARADIR/extras_$MODE" ./extras
         fi
     fi
+    echo "Start=$STARTNUM"  
 fi

--- a/work/scripts/setup
+++ b/work/scripts/setup
@@ -112,9 +112,11 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
 
     if [ "$MODE" = "continue" ]; then
         STARTNUM=$(latest_dump_number)
+	echo "Start=$STARTNUM"
         update_startfile "continue" "" "$STARTNUM"
     else
         STARTNUM=0
+	echo "Start=$STARTNUM"
         # Append " test" if requested
         SIMTYPE_TO_WRITE="$MODE"
         if [ "$TESTFLAG" = "test" ]; then


### PR DESCRIPTION
`./setup continue` is a great luxury. Yet, I still find myself typing `less startfile` to check if the start number is correct. 

So, I've changed `setup` to echo the `STARTNUM` variable* after `./setup continue` is entered. 

*Note, I'm not sure how the code works, but I believe `STARTNUM` stores the value to be inserted next to `start=` under `&startcon` in `startfile`. Please let me know if this is wrong, or if my idea can be better implemented :). 