### PR TITLE
Bug fixes related to simtype = commonenvelope

### DIFF
--- a/src/init/commonenvelope.f90
+++ b/src/init/commonenvelope.f90
@@ -186,9 +186,6 @@ subroutine commonenvelope
   if(i>=is.and.i<=ie)p(i,js:je,ks:ke) = p1d(i)
  end do
 
-! Remember core mass
- if (is==is_global) mc(is-1) = mcore
-
 ! place colliding object
  sink(2)%mass = compmass
  sink(2)%lsoft = compsoft

--- a/src/init/stellarcollision.f90
+++ b/src/init/stellarcollision.f90
@@ -175,7 +175,7 @@ end subroutine stellarcollision
 
 !\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 !
-!                          SUBROUTINE STELLARCOLLISION_RSG
+!                       SUBROUTINE STELLARCOLLISION_RSG
 !
 !\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 

--- a/src/main/output.f90
+++ b/src/main/output.f90
@@ -191,7 +191,6 @@ subroutine evo_output
   Egtot = sum(d(is:ie,js:je,ks:ke) &
               *(totphi(is:ie,js:je,ks:ke)-0.5d0*grvphi(is:ie,js:je,ks:ke)) &
               *dvol(is:ie,js:je,ks:ke))
-  if (is==is_global) Mtot = Mtot + mc(is-1)
 
   Mbound=0d0;Ebound=0d0;Jbound=0d0
   do k = ks, ke
@@ -218,7 +217,7 @@ subroutine evo_output
    Ebound = 2d0*Ebound
    Jbound = 2d0*Jbound
   end if
-  if (include_extgrv .and. is==is_global) Mbound = Mbound+mc(is-1)
+
  end if
 
  if(dim>=2.and.crdnt>=1)then

--- a/src/main/sinks.f90
+++ b/src/main/sinks.f90
@@ -74,7 +74,7 @@ subroutine sink_accretion
  kappa = 0.d0 ! Temporary: ignore radiative heating
 
  do n = 1, nsink
-  if(sink(n)%mass<=0d0)cycle
+  if(sink(n)%laccr<=0d0)cycle
   accmass = 0d0
   accmom  = 0d0
   accang  = 0d0


### PR DESCRIPTION
1. Subroutine `sink_accretion` in `sinks.f90` was previously used with a zero mass particle in a simulation with another sink particle, which had some mass. In that simulation, the subroutine was only desired for the particle that was assigned some mass, so the subroutine differentiated between each particle by their mass.

 However, sink particles will not always have zero mass, so we instead differentiate between them with 'laccr', since this is a parameter that is only assigned to particles that require `sink_accretion` treatment.  
 
 2. Redundant use of `mc(is-1)`. We remove the line in `commonenvelope.f90` that assigns the variable a value.