### PR TITLE
Fix horpy-Jupyter notebook problem

### DIFF
--- a/scripts/horpy.f90
+++ b/scripts/horpy.f90
@@ -52,12 +52,13 @@ subroutine setup_python(dir)
  call domain_decomp
 
 ! call allocate_subset
- if(.not.allocated(d))call allocations
+ if(allocated(d))call deallocate_all
+ call allocations
 
- if(include_sinks.and..not.allocated(sink_x))then
-  allocate(sink_x(1:3,1:nsink))
+ if(include_sinks)then
+  if(allocated(sink_x))deallocate(sink_x,sink_v,sink_mass,sink_mdot)
+  allocate(sink_x(1:3,1:nsink),sink_mass(1:nsink))
   allocate(sink_v,mold=sink_x)
-  allocate(sink_mass(1:nsink))
   allocate(sink_mdot,mold=sink_mass)
  end if
 
@@ -98,6 +99,7 @@ subroutine read_gridfile(gridfile)
  xi1s = xi1(is-1)
 
  if(crdnt==2)then
+  if(allocated(sinc))deallocate(sinc,sini,cosc,cosi)
   allocate( sinc, sini, cosc, cosi, mold=x2 )
   do j = js_global-2, je_global+2
    sinc(j)=real(sin(real(x2 (j),kind=16)),kind=8)!sin0(x2 (j))

--- a/scripts/horpy.sh
+++ b/scripts/horpy.sh
@@ -90,7 +90,11 @@ F2PY="$PYTHON -m $F2PY_MODULE"
 # Generate .pyf signature interface
 # -----------------------------------------------------------------------------
 echo "Generating .pyf interface file..."
-$F2PY -h "$PYF_FILE" -m horpy "$PROJECT_ROOT/src/main/modules.f90" "$SCRIPT_DIR/horpy.f90"
+$F2PY -h "$PYF_FILE" -m horpy \
+      "$PROJECT_ROOT/src/main/modules.f90" \
+      "$PROJECT_ROOT/src/main/opacity.f90" \
+      "$PROJECT_ROOT/src/main/ionization.f90" \
+      "$SCRIPT_DIR/horpy.f90"
 
 # -----------------------------------------------------------------------------
 # Compile Fortran code into shared object
@@ -113,6 +117,7 @@ $F2PY -c "$SCRIPT_DIR/horpy.pyf" -m horpy \
 # -----------------------------------------------------------------------------
 # Move resulting .so file into the venv's site-packages/
 # -----------------------------------------------------------------------------
+
 SITE_PACKAGES_DIR="$($PYTHON -c 'import site; print(site.getsitepackages()[0])')"
 
 if [ ! -d "$SITE_PACKAGES_DIR" ]; then

--- a/src/main/allocations.f90
+++ b/src/main/allocations.f90
@@ -48,7 +48,7 @@ subroutine allocations
 
  allocate(dvol(is_global-2:ie_global+2,js_global-2:je_global+2,ks_global-2:ke_global+2))
  allocate(idetg3,sa1,sa2,sa3,Imom,mold=dvol)
- allocate(car_x(1:3,is-1:ie+1,js-1:je+1,ks-1:ke+1))
+ if(crdnt/=0)allocate(car_x(1:3,is-1:ie+1,js-1:je+1,ks-1:ke+1))
 
 ! 3 dimensional arrays =======================================================
 ! physical variables
@@ -333,5 +333,90 @@ subroutine allocations
 
  return
 end subroutine allocations
+
+
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+!
+!                          SUBROUTINE DEALLOCATE_ALL
+!
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+! PURPOSE: To deallocate all variables that are allocated in allocations
+
+subroutine deallocate_all
+
+ use settings
+ use derived_types,only:null_sink
+ use grid
+ use physval
+ use gravmod
+ use sink_mod
+ use dirichlet_mod
+
+!-----------------------------------------------------------------------------
+
+! 1 dimensional arrays =======================================================
+! grid-related variables
+ deallocate(x1,xi1,dx1,dxi1,idx1,idxi1)
+ deallocate(x2,xi2,dx2,dxi2,idx2,idxi2)
+ deallocate(x3,xi3,dx3,dxi3,idx3,idxi3)
+
+!  metric-related variables
+ deallocate(detg1,idetg1,sx1,g22,scot,sisin,&
+            detg2,idetg2,g33,dvol,idetg3,sa1,sa2,sa3,Imom)
+ if(crdnt/=0)deallocate(car_x)
+
+
+! 3 dimensional arrays =======================================================
+! physical variables
+!  Strictly non-zero quantities
+ deallocate(d,p,e,T,ptot,cs,eint,erad,imu,phi,&
+            v1,v2,v3,b1,b2,b3,grv1,grv2,grv3,shock)
+
+! 4 dimensional arrays =======================================================
+! gradients
+ deallocate(dd,de,dphi,dm1,dm2,dm3,db1,db2,db3,dmu)
+ if(radswitch>0)deallocate(der)
+
+! conserved quantities and flux
+ deallocate(u,flux1,flux2,flux3)
+ deallocate(src,uorg)
+
+! >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+
+! gravity-related variables
+ if(gravswitch>=1)then
+  deallocate(grvphi,totphi,hgsrc,grvpsi,gsrc,lapphi,grvphiorg)
+!  for gravbound
+  deallocate(phiio,phiii,phi1o,phi3i,phi3o,mc)
+ end if
+
+! deallocate Dirichlet variables if Dirichlet boundary is applied
+ if(bc1is==9.or.bc1os==9.or.bc2is==9.or.bc2os==9.or.bc3is==9.or.bc3os==9.or. &
+    bc1iv==9.or.bc1ov==9.or.bc2iv==9.or.bc2ov==9.or.bc3iv==9.or.bc3ov==9.or. &
+    is_test)then
+  deallocate(d0,p0,v10,v20,v30,b10,b20,b30)
+ end if
+
+! deallocate chemical composition if compswitch/=0
+ if(compswitch>0)then
+  deallocate(spc,spcorg,dspc,spcflx,species)
+  if(bc1is==9.or.bc1os==9.or.bc2is==9.or.bc2os==9.or.bc3is==9.or.bc3os==9.or. &
+     bc1iv==9.or.bc1ov==9.or.bc2iv==9.or.bc2ov==9.or.bc3iv==9.or.bc3ov==9)then
+   deallocate(spc0)
+  end if
+ end if
+
+! deallocate external gravitational field if necessary
+ if(include_extgrv)deallocate(extgrv)
+
+! >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+
+! deallocate sink particle-related variables if necessary
+ if(include_sinks)deallocate(snkphi,sink)
+
+ return
+end subroutine deallocate_all
+
 
 end module allocation_mod

--- a/src/main/io.F90
+++ b/src/main/io.F90
@@ -92,12 +92,22 @@ subroutine open_file_write_ascii(filename, fh)
 #endif
 end subroutine open_file_write_ascii
 
-subroutine open_file_read(filename, fh)
+subroutine open_file_read(filename, fh, istat)
   character(len=*), intent(in) :: filename
-  integer, intent(out) :: fh
-#ifndef MPI
-  integer :: istat
-#endif
+  integer, intent(out) :: fh, istat
+  logical:: exist
+
+! Check if file exists.
+! This was added in response to weird Jupyter notebook behaviour
+  inquire(file=filename,exist=exist)
+  if(exist)then
+   istat = 0
+  else
+   print*,'Error: File does not exist!!'
+   print*,'input file name = ',trim(filename)
+   istat = 1
+   return
+  end if
 
 #ifdef MPI
   offset = 0   ! reset the offset counter
@@ -113,6 +123,7 @@ subroutine open_file_read(filename, fh)
   if(istat/=0)then
     print*,'Error opening binary dump file'
     print'(3a)','File name = "',trim(filename),'"'
+    print*,'iostat = ',istat
     stop
   end if
 #endif

--- a/src/main/metric.f90
+++ b/src/main/metric.f90
@@ -54,6 +54,7 @@ subroutine metric
 ! Cylindrical >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
  case(1)
 
+  if(allocated(rdis))deallocate(rdis,sincyl,coscyl)
   allocate( rdis(-1:gie+2,gks-2:gke+2) )
   allocate( sincyl,coscyl,mold=rdis )
 
@@ -151,6 +152,7 @@ subroutine metric
   end do
 
   if(include_extforce)then
+   if(allocated(spinc_r))deallocate(spinc_r,spinc_t)
    allocate(spinc_r(is_global:ie_global),spinc_t(js_global:je_global))
    do i = is_global, ie_global
     spinc_r(i) = 0.75d0*(xi1(i)**2+xi1(i-1)**2) &

--- a/src/main/readbin.f90
+++ b/src/main/readbin.f90
@@ -25,11 +25,12 @@ subroutine readbin(filename)
  use sink_mod,only:sink
 
  character(len=*),intent(in):: filename
- integer:: un
+ integer:: un, ierr
 
 !-----------------------------------------------------------------------------
 
- call open_file_read(filename, un)
+ call open_file_read(filename, un, ierr)
+ if(ierr/=0)return
 
  call read_dummy_recordmarker(un)
  call read_var(un, tn)
@@ -154,11 +155,12 @@ subroutine read_extgrv(filename)
  use gravmod, only:coremass, extgrv, mc
  use io, only:open_file_read, read_dummy_recordmarker, read_var, read_extgrv_array, close_file
  character(len=*), intent(in) :: filename
- integer:: ui, istart, iend, jstart, jend, kstart, kend
+ integer:: ui, istart, iend, jstart, jend, kstart, kend, ierr
 
  extgrv = 0d0
 
- call open_file_read(filename, ui)
+ call open_file_read(filename, ui, ierr)
+ if(ierr/=0) return
 
  call read_dummy_recordmarker(ui)
  call read_var(ui, coremass)

--- a/work/Makefile
+++ b/work/Makefile
@@ -126,7 +126,7 @@ $(TARGETL): $(OBJL_F)
 	$(FC) $(FCFLAG) -o $@ $(OBJL_F)
 
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.F90
-	$(FC) $(FPPFLAG) $(FCFLAG) -c $< -o $@ $(MODFLAG)$(OBJ_DIR)
+	$(FC) $(FCFLAG) -c $< -o $@ $(MODFLAG)$(OBJ_DIR) $(FPPFLAG)
 
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.f90
 	$(FC) $(FCFLAG) -c $< -o $@ $(MODFLAG)$(OBJ_DIR)

--- a/work/data/plot.py
+++ b/work/data/plot.py
@@ -1,15 +1,16 @@
 # Import horpy.so
 import horpy as hp
+from horpy import readbin_python as hpr
 
 # Set up HORMONE variables as it would in the simulation
 # Give the path to the work directory as the argument
-hp.readbin_python.setup_python('../')
+hpr.setup_python('../')
 
 # You can read grid information by feeding in the gridfile
-hp.readbin_python.read_gridfile('gridfile.bin')
+hpr.read_gridfile('gridfile.bin')
 
 # You can read binary dumps by feeding in the binXX.dat files
-hp.readbin_python.read_binfile('bin00000000000ms.dat')
+hpr.read_binfile('bin00000000000s.dat')
 
 # You can directly access all the HORMONE variables in src/main/modules.f90
 # Most of the relevant variables should be in the following modules
@@ -24,21 +25,21 @@ x1array_full = hp.grid.x1.copy()
 # get_interior_1d: For 1D variables like x1, x2, x3, etc
 # get_interior_3d: For 3D variables like d, p, e, v1, v2, v3, etc
 # get_interior_4d: For 4D variables like spc
-darray  = hp.readbin_python.get_interior_3d(hp.physval.d)
-parray  = hp.readbin_python.get_interior_3d(hp.physval.p)
-x1array = hp.readbin_python.get_interior_1d(hp.grid.x1)
-x2array = hp.readbin_python.get_interior_1d(hp.grid.x2)
-x3array = hp.readbin_python.get_interior_1d(hp.grid.x3)
-#spcarray = hp.readbin_python.get_interior_4d(hp.physval.spc)
+darray  = hpr.get_interior_3d(hp.physval.d)
+parray  = hpr.get_interior_3d(hp.physval.p)
+x1array = hpr.get_interior_1d(hp.grid.x1)
+x2array = hpr.get_interior_1d(hp.grid.x2)
+x3array = hpr.get_interior_1d(hp.grid.x3)
+#spcarray = hpr.get_interior_4d(hp.physval.spc)
 
 # Sink particle information is stored directly under readbin_python
 # sink_x(3,n): 2D array where first index is for x1,x2,x3 coordinates and second index is particle number
 # sink_v(3,n): 2D array where first index is for v1,v2,v3 velocity elements and second index is particle number
 # sink_mass(n): 1D array for sink particle masses
 # sink_mdot(n): 1D array for sink particle mass accretion rates
-#sink_x_array = hp.readbin_python.sink_x.copy()
-#sink_v_array = hp.readbin_python.sink_v.copy()
-#sink_mass_array = hp.readbin_python.sink_mass
-#sink_mdot_array = hp.readbin_python.sink_mdot
+#sink_x_array = hpr.sink_x.copy()
+#sink_v_array = hpr.sink_v.copy()
+#sink_mass_array = hpr.sink_mass
+#sink_mdot_array = hpr.sink_mdot
 
 #exec(open('plot.py').read())


### PR DESCRIPTION
In `horpy.f90`, most of the routines were only designed for one-time usage.
In practical usages of horpy, you may want to read in multiple directories of hormone that have different grid structures within the same script. In this case, the grid and physical variables must be deallocated before allocating them again.
Here, I add a deallocation routine before any allocation if the variables are already allocated.

I also put in a check for file existence before opening them. This was only a problem in Jupyter notebook usage. Resolves #150 