### PR TITLE
Change externalforce structure

### DIFF
--- a/para/parameters_base
+++ b/para/parameters_base
@@ -156,6 +156,14 @@
 &partcon include_particles=.false. maxptc=0 /
 
 
+########################## EXTERNAL FORCE CONTROLS #########################
+! include_spinup: Switch to add rigid body spinup
+! omegadot: Torque for spinup in rad/s^2
+! j_max: Maximum allowed specific angular momentum (cgs)
+
+&extfcon include_spinup=.false. omegadot=0d0 j_max=0d0 /
+
+
 ############################### TEST CONTROLS ##############################
 ! test_tol: tolerance for test simulation
 ! Mach_tol: Normalize velocities by this Mach number to avoid dividing by zero

--- a/src/main/checksetup.f90
+++ b/src/main/checksetup.f90
@@ -13,6 +13,7 @@ subroutine checksetup
 ! purpose: To check whether the setups are consistent.
 
   use settings
+  use external_settings
   use grid
   use physval
   use utils

--- a/src/main/checksetup.f90
+++ b/src/main/checksetup.f90
@@ -262,6 +262,9 @@ subroutine checksetup
    include_sinks = .true.
   end if
 
+! Enable external force if using spinup
+  if(include_spinup)include_extforce = .true.
+
 ! Only do accretion when sinks are enabled
   if(.not.include_sinks) include_accretion = .false.
 

--- a/src/main/externalforce.f90
+++ b/src/main/externalforce.f90
@@ -13,75 +13,230 @@ contains
 
 subroutine externalforce
 
+ use settings,only:frame
+ use external_settings,only:include_spinup
  use grid
  use physval
  use utils,only:polcar,cylcar,get_vpol,get_vcyl
 
  integer:: i,j,k
- real(8),dimension(1:3):: atot,ftot,xcar
+ real(8),dimension(1:3):: ftot,xcar,atotijk
+ real(8),allocatable,dimension(:,:,:,:):: atot
 
 !-----------------------------------------------------------------------------
 
+ allocate(atot(1:3,is:ie,js:je,ks:ke))
+
+! Initialize atot
+!$omp parallel do private(i,j,k) collapse(3)
+ do k = ks, ke
+  do j = js, je
+   do i = is, ie
+    atot(1:3,i,j,k) = 0d0
+   end do
+  end do
+ end do
+!$omp end parallel do
+
+! Get frame force
+ if(frame>0)       call frame_force(atot)
+
+! Spin up star
+ if(include_spinup)call spinup(atot)
+
+
+! Add external acceleration to the source term in hydrodynamic equations
  select case(crdnt)
  case(0) ! cartesian coordinates
-!$omp parallel do private(i,j,k,atot,ftot) collapse(3)
+!$omp parallel do private(i,j,k,ftot,atotijk) collapse(3)
   do k = ks, ke
    do j = js, je
     do i = is, ie
-     atot = frame_acc
-     ftot = d(i,j,k) * atot
+     atotijk = atot(1:3,i,j,k)
+     ftot = d(i,j,k) * atotijk
      src(i,j,k,imo1) = src(i,j,k,imo1) + ftot(1)
      src(i,j,k,imo2) = src(i,j,k,imo2) + ftot(2)
      src(i,j,k,imo3) = src(i,j,k,imo3) + ftot(3)
      src(i,j,k,iene) = src(i,j,k,iene) &
                      + (ftot(1)*v1(i,j,k)+ftot(2)*v2(i,j,k)+ftot(3)*v3(i,j,k)) &
-                     + 0.5d0*dot_product(ftot,atot)*dt
+                     + 0.5d0*dot_product(ftot,atotijk)*dt
     end do
    end do
   end do
 !$omp end parallel do
 
  case(1) ! cylindrical coordinates
-!$omp parallel do private(i,j,k,xcar,atot,ftot) collapse(3)
+!$omp parallel do private(i,j,k,ftot,atotijk) collapse(3)
   do k = ks, ke
    do j = js, je
     do i = is, ie
-     xcar = cylcar([x1(i),x2(j),x3(k)])
-     call get_vcyl(xcar,frame_acc,atot(1),atot(2),atot(3))
-     ftot = d(i,j,k) * atot
+     atotijk =  atot(1:3,i,j,k)
+     ftot = d(i,j,k) * atotijk
      src(i,j,k,imo1) = src(i,j,k,imo1) + ftot(1)
      src(i,j,k,imo2) = src(i,j,k,imo2) + ftot(2)
      src(i,j,k,imo3) = src(i,j,k,imo3) + ftot(3)
      src(i,j,k,iene) = src(i,j,k,iene) &
                      + (ftot(1)*v1(i,j,k)+ftot(2)*v2(i,j,k)+ftot(3)*v3(i,j,k)) &
-                     + 0.5d0*dot_product(ftot,atot)*dt
+                     + 0.5d0*dot_product(ftot,atotijk)*dt
     end do
    end do
   end do
 !$omp end parallel do
 
  case(2) ! spherical coordinates
-!$omp parallel do private(i,j,k,atot,ftot) collapse(3)
+!$omp parallel do private(i,j,k,ftot,atotijk) collapse(3)
   do k = ks, ke
    do j = js, je
     do i = is, ie
-     call get_vpol(car_x(:,i,j,k),x3(k),frame_acc,atot(1),atot(2),atot(3))
-     ftot = d(i,j,k) * atot
+     atotijk = atot(1:3,i,j,k)
+     ftot = d(i,j,k) * atotijk
      src(i,j,k,imo1) = src(i,j,k,imo1) + ftot(1)
      src(i,j,k,imo2) = src(i,j,k,imo2) + ftot(2)
      src(i,j,k,imo3) = src(i,j,k,imo3) + ftot(3)
      src(i,j,k,iene) = src(i,j,k,iene) &
                      + (ftot(1)*v1(i,j,k)+ftot(2)*v2(i,j,k)+ftot(3)*v3(i,j,k)) &
-                     + 0.5d0*dot_product(ftot,atot)*dt
+                     + 0.5d0*dot_product(ftot,atotijk)*dt
     end do
    end do
   end do
 !$omp end parallel do
  end select
 
+ deallocate(atot)
+
+end subroutine externalforce
+
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+!
+!                           SUBROUTINE FRAME_FORCE
+!
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+! PURPOSE: Add frame force to the total acceleration
+
+subroutine frame_force(atot)
+
+ use grid
+ use utils,only:polcar,cylcar,get_vpol,get_vcyl
+
+ real(8),allocatable,dimension(:,:,:,:),intent(inout):: atot
+ integer:: i,j,k
+ real(8),dimension(1:3):: aframe, xcar
+
+!-----------------------------------------------------------------------------
+
+ select case(crdnt)
+ case(0) ! cartesian coordinates
+!$omp parallel do private(i,j,k) collapse(3)
+  do k = ks, ke
+   do j = js, je
+    do i = is, ie
+     atot(1:3,i,j,k) = atot(1:3,i,j,k) + frame_acc(1:3)
+    end do
+   end do
+  end do
+!$omp end parallel do
+
+ case(1) ! cylindrical coordinates
+!$omp parallel do private(i,j,k,xcar,aframe) collapse(3)
+  do k = ks, ke
+   do j = js, je
+    do i = is, ie
+     xcar = cylcar([x1(i),x2(j),x3(k)])
+     call get_vcyl(xcar,frame_acc,aframe(1),aframe(2),aframe(3))
+     atot(1:3,i,j,k) = atot(1:3,i,j,k) + aframe(1:3)
+    end do
+   end do
+  end do
+!$omp end parallel do
+
+ case(2) ! spherical coordinates
+!$omp parallel do private(i,j,k,aframe) collapse(3)
+  do k = ks, ke
+   do j = js, je
+    do i = is, ie
+     call get_vpol(car_x(:,i,j,k),x3(k),frame_acc,aframe(1),aframe(2),aframe(3))
+     atot(1:3,i,j,k) = atot(1:3,i,j,k) + aframe(1:3)
+    end do
+   end do
+  end do
+!$omp end parallel do
+ end select
 
  return
-end subroutine externalforce
+end subroutine frame_force
+
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+!
+!                             SUBROUTINE SPINUP
+!
+!\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+! PURPOSE: To spin up star in rigid rotation but capped at Keplerian rotation
+
+subroutine spinup(atot)
+
+ use external_settings,only:omegadot,j_max
+ use grid
+ use physval,only:v1,v2,v3
+ use gravmod,only:extgrv,totphi
+
+ real(8),allocatable,dimension(:,:,:,:),intent(inout):: atot
+ integer:: i,j,k
+ real(8):: v_kep,j_local,v_phi
+
+!-----------------------------------------------------------------------------
+
+ select case(crdnt)
+ case(0) ! cartesian coordinates
+!$omp parallel do private(i,j,k,j_local,v_kep,v_phi) collapse(3)
+  do k = ks, ke
+   do j = js, je
+    do i = is, ie
+     j_local = x1(i)*v2(i,j,k)-x2(j)*v1(i,j,k)
+     v_phi = (-v1(i,j,k)*x2(j)+v2(i,j,k)*x1(i))/sqrt(x1(i)**2+x2(j)**2)
+     v_kep = sqrt(-totphi(i,j,k))
+     if(j_local<=j_max.and.v_phi<=v_kep)then
+      atot(1,i,j,k) = atot(1,i,j,k) - omegadot*x2(j)
+      atot(2,i,j,k) = atot(2,i,j,k) + omegadot*x1(i)
+     end if
+    end do
+   end do
+  end do
+!$omp end parallel do
+
+ case(1) ! cylindrical coordinates
+!$omp parallel do private(i,j,k,j_local,v_kep) collapse(3)
+  do k = ks, ke
+   do j = js, je
+    do i = is, ie
+     j_local = x1(i)*v2(i,j,k)
+     v_kep = sqrt(-totphi(i,j,k))
+     if(j_local<=j_max.and.v2(i,j,k)<=v_kep)then
+      atot(2,i,j,k) = atot(2,i,j,k) + omegadot*spinc_r(i)
+     end if
+    end do
+   end do
+  end do
+!$omp end parallel do
+
+ case(2) ! spherical coordinates
+!$omp parallel do private(i,j,k,j_local,v_kep) collapse(3)
+  do k = ks, ke
+   do j = js, je
+    do i = is, ie
+     j_local = x1(i)*sinc(j)*v3(i,j,k)
+     v_kep = sqrt(-totphi(i,j,k))
+     if(j_local<=j_max.and.v3(i,j,k)<=v_kep)then
+      atot(3,i,j,k) = atot(3,i,j,k) + omegadot*spinc_r(i)*spinc_t(j)
+     end if
+    end do
+   end do
+  end do
+!$omp end parallel do
+ end select
+
+end subroutine spinup
 
 !\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 !

--- a/src/main/externalforce.f90
+++ b/src/main/externalforce.f90
@@ -20,7 +20,7 @@ subroutine externalforce
  use utils,only:polcar,cylcar,get_vpol,get_vcyl
 
  integer:: i,j,k
- real(8),dimension(1:3):: ftot,xcar,atotijk
+ real(8),dimension(1:3):: ftot,atotijk
  real(8),allocatable,dimension(:,:,:,:):: atot
 
 !-----------------------------------------------------------------------------

--- a/src/main/externalforce.f90
+++ b/src/main/externalforce.f90
@@ -177,9 +177,9 @@ end subroutine frame_force
 subroutine spinup(atot)
 
  use external_settings,only:omegadot,j_max
- use grid
+ use grid,only:crdnt,is,ie,js,je,ks,ke,x1,x2,sinc,spinc_r,spinc_t
  use physval,only:v1,v2,v3
- use gravmod,only:extgrv,totphi
+ use gravmod,only:totphi
 
  real(8),allocatable,dimension(:,:,:,:),intent(inout):: atot
  integer:: i,j,k

--- a/src/main/externalforce.f90
+++ b/src/main/externalforce.f90
@@ -15,8 +15,8 @@ subroutine externalforce
 
  use settings,only:frame
  use external_settings,only:include_spinup
- use grid
- use physval
+ use grid,only:crdnt,is,ie,js,je,ks,ke,dt
+ use physval,only:d,v1,v2,v3,src,imo1,imo2,imo3,iene
  use utils,only:polcar,cylcar,get_vpol,get_vcyl
 
  integer:: i,j,k
@@ -108,7 +108,7 @@ end subroutine externalforce
 
 !\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 !
-!                           SUBROUTINE FRAME_FORCE
+!                            SUBROUTINE FRAME_FORCE
 !
 !\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
@@ -116,7 +116,7 @@ end subroutine externalforce
 
 subroutine frame_force(atot)
 
- use grid
+ use grid,only:crdnt,is,ie,js,je,ks,ke,x1,x2,x3,car_x,frame_acc
  use utils,only:polcar,cylcar,get_vpol,get_vcyl
 
  real(8),allocatable,dimension(:,:,:,:),intent(inout):: atot
@@ -168,7 +168,7 @@ end subroutine frame_force
 
 !\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 !
-!                             SUBROUTINE SPINUP
+!                              SUBROUTINE SPINUP
 !
 !\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 

--- a/src/main/metric.f90
+++ b/src/main/metric.f90
@@ -13,7 +13,7 @@ contains
 
 subroutine metric
 
- use settings,only:include_extforce
+ use external_settings,only:include_spinup
  use grid
  use utils,only:polcar
 
@@ -100,6 +100,15 @@ subroutine metric
    sa3  = sa3  * 4d0
   end if
 
+  if(include_spinup)then
+   if(allocated(spinc_r))deallocate(spinc_r)
+   allocate(spinc_r(is_global:ie_global))
+   do i = is_global, ie_global
+    spinc_r(i) = 2d0/3d0*(xi1(i)**2+xi1(i)*xi1(i-1)+xi1(i-1)**2) &
+                        /(xi1(i)+xi1(i-1))
+   end do
+  end if
+
 ! Spherical >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
  case(2)
 
@@ -151,7 +160,7 @@ subroutine metric
    sisin(j) = ( xi2(j) - xi2(j-1) ) / ( cosi(j-1) - cosi(j) )
   end do
 
-  if(include_extforce)then
+  if(include_spinup)then
    if(allocated(spinc_r))deallocate(spinc_r,spinc_t)
    allocate(spinc_r(is_global:ie_global),spinc_t(js_global:je_global))
    do i = is_global, ie_global

--- a/src/main/modules.f90
+++ b/src/main/modules.f90
@@ -27,9 +27,9 @@ module settings
 ! test tolerance
  real(8):: test_tol, Mach_tol
 ! switches
- logical:: solve_i, solve_j, solve_k, solve_hydro, solve_grav
+ logical:: solve_i, solve_j, solve_k, solve_hydro, solve_grav, is_test
  logical:: include_extgrv, include_particles, include_cooling, mag_on
- logical:: include_extforce, include_sinks, include_accretion, is_test
+ logical:: include_extforce, include_sinks, include_accretion
  logical:: write_other_vel, write_shock, write_evo, write_other_slice
  logical:: write_temp, write_mc, output_ascii
  logical:: grav_init_other, grav_init_relax
@@ -173,3 +173,13 @@ module ejectamod
   character(len=40):: ejtbinfile
 
 end module ejectamod
+
+!XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+module external_settings
+
+ implicit none
+
+ logical:: include_spinup
+ real(8):: omegadot,j_max
+
+end module external_settings

--- a/src/main/setup.f90
+++ b/src/main/setup.f90
@@ -105,6 +105,7 @@ end subroutine read_default
 subroutine read_parameters(filename)
 
  use settings
+ use external_settings
  use grid
  use physval
  use opacity_mod
@@ -139,6 +140,7 @@ subroutine read_parameters(filename)
                     lambdatype, rbtype
  namelist /partcon/ include_particles, maxptc
  namelist /mat_con/ matrix_solver
+ namelist /extfcon/ include_spinup, omegadot, j_max
  namelist /testcon/ test_tol, Mach_tol
 
  if(filename=='')return
@@ -159,6 +161,7 @@ subroutine read_parameters(filename)
  read(ui,NML=rad_con,iostat=istat);rewind(ui)
  read(ui,NML=partcon,iostat=istat);rewind(ui)
  read(ui,NML=mat_con,iostat=istat);rewind(ui)
+ read(ui,NML=extfcon,iostat=istat);rewind(ui)
  read(ui,NML=testcon,iostat=istat)
  close(ui)
 


### PR DESCRIPTION
Changed the structure of how external forces are treated.
Previously, it was sort of left to the user to add whatever they want. To make it a bit more user friendly, I am now planning to add pre-made routines which can be used with a few parameters.

There is now a namelist called `extfcon` which sets parameters for different forms of external forces.
For now, there is only spinup as an example.